### PR TITLE
Refactor i2s

### DIFF
--- a/lib_xua/src/core/audiohub/xua_audiohub.xc
+++ b/lib_xua/src/core/audiohub/xua_audiohub.xc
@@ -1229,7 +1229,7 @@ unsigned static deliver_slave(chanend ?c_out, chanend ?c_spd_out
             /* Request digital data (with prefill) */
             outuint(c_dig_rx, 0);
 #endif
-#if defined(SPDIF_TX) && (NUM_USB_CHAN_OUT > 0)
+#if ((XUA_SPDIF_TX_EN) && (NUM_USB_CHAN_OUT > 0))
             outuint(c_spd_out, samplesOut[SPDIF_TX_INDEX]);  /* Forward sample to S/PDIF Tx thread */
             unsigned sample = samplesOut[SPDIF_TX_INDEX + 1];
             outuint(c_spd_out, sample);                      /* Forward sample to S/PDIF Tx thread */
@@ -1723,7 +1723,7 @@ void XUA_AudioHub(chanend ?c_mix_out
 #else
                 command = deliver_master(c_mix_out
 #endif
-#ifdef XUA_SPDIF_TX_EN
+#if (XUA_SPDIF_TX_EN)
                    , c_spdif_out
 #else
                    , null


### PR DESCRIPTION
I have fixed a number of issues:

- I2S slave with >1 data line
- TDM slave (fixed synch check + now supports single BCLK pulse synch as well as square)
- TDM slave with > 1 data line
- DSD on XS2
- DFU build error

To do this I needed to refactor deliver into master and slave. I found it very difficult to keep check of the nested #ifs and this made things easier and there is some divergence now especially with DSD (master only) and synch check (slave only). I have also pulled out DSD into in-line fns.

There is an associated regression (sim only currently) which I have extended to cover a much more complete matrix of interface types:

https://github.com/ed-xmos/sw_vocalfusion/commits/xua_i2s_test

These all pass. TBH the xua i2s tests should live in xua but until we have a working builder it's probably better to keep them where they'll run. I will make a pull request for this test when this PR is merged as it is dependent obviously. Only missing regression is DSD now, but this will take longer to write as we have no loopback option.

In addition I have done HW testing on the 216mc board and it all of the I2S modes work OK, so I am happy for this to be merged.
  