### PR TITLE
Fix I2S_MODE_TDM handling and Dop Check build fix

### DIFF
--- a/lib_xua/src/core/audiohub/xua_audiohub.xc
+++ b/lib_xua/src/core/audiohub/xua_audiohub.xc
@@ -282,7 +282,6 @@ static inline void DoDsdDop(int &everyOther, unsigned samplesOut[], unsigned &ds
         asm volatile("out res[%0], %1"::"r"(p_dsd_dac[1]),"r"(bitrev(dsdSample_r)));
     }
 }
-#endif
 
 /* When DSD is enabled and streaming is standard PCM, this function checks for a series of DoP markers in the upper byte.
    If found it will exit deliver() with the command to restart in DoP mode.
@@ -335,6 +334,7 @@ static inline int DoDsdDopCheck(unsigned &dsdMode, int &dsdCount, unsigned curSa
     }
     return 1;
 }
+#endif
 
 #if !CODEC_MASTER
 static inline void InitPorts_master(unsigned divide)
@@ -404,7 +404,7 @@ static inline void InitPorts_slave(unsigned divide)
     p_lrclk when pinseq(1) :> void;
     p_lrclk when pinseq(0) :> void;
     p_lrclk when pinseq(1) :> void;
-#ifdef I2S_MODE_TDM
+#if I2S_MODE_TDM
     p_lrclk when pinseq(0) :> void;
     p_lrclk when pinseq(1) :> void @ tmp;
 #else
@@ -607,7 +607,7 @@ unsigned static deliver_master(chanend ?c_out, chanend ?c_spd_out
                 /* LR clock delayed by one clock, This is so MSB is output on the falling edge of BCLK
                  * after the falling edge on which LRCLK was toggled. (see I2S spec) */
                 /* Generate clocks LR Clock low - LEFT */
-#ifdef I2S_MODE_TDM
+#if I2S_MODE_TDM
                 p_lrclk <: 0x00000000;
 #else
                 p_lrclk <: 0x80000000;
@@ -734,7 +734,7 @@ unsigned static deliver_master(chanend ?c_out, chanend ?c_spd_out
                 }
 #endif
 
-#ifdef I2S_MODE_TDM
+#if I2S_MODE_TDM
                 if(frameCount == (I2S_CHANS_PER_FRAME-2))
                     p_lrclk <: 0x80000000;
                 else
@@ -770,13 +770,12 @@ unsigned static deliver_master(chanend ?c_out, chanend ?c_spd_out
             }  // !dsdMode
 
 
-            if((DSD_CHANS_DAC != 0) && (NUM_USB_CHAN_OUT > 0))
-            {
-                if(DoDsdDopCheck(dsdMode, dsdCount, curSamFreq, samplesOut, dsdMarker) == 0)
-                    return 0;
-            }
+#if (DSD_CHANS_DAC != 0) && (NUM_USB_CHAN_OUT > 0)
+            if(DoDsdDopCheck(dsdMode, dsdCount, curSamFreq, samplesOut, dsdMarker) == 0)
+                return 0;
+#endif
 
-#ifdef I2S_MODE_TDM
+#if I2S_MODE_TDM
             /* Increase frameCount by 2 since we have output two channels (per data line) */
             frameCount+=2;
             if(frameCount == I2S_CHANS_PER_FRAME)
@@ -1143,7 +1142,7 @@ unsigned static deliver_slave(chanend ?c_out, chanend ?c_spd_out
 #endif // (I2S_CHANS_DAC != 0) && (NUM_USB_CHAN_OUT != 0)
 
 
-#ifdef I2S_MODE_TDM
+#if I2S_MODE_TDM
             /* Increase frameCount by 2 since we have output two channels (per data line) */
             frameCount+=2;
             if(frameCount == I2S_CHANS_PER_FRAME)


### PR DESCRIPTION
Commit fe93288 changed I2S_MODE_TDM to be always defined and treated as a boolean, but xua_audiohub.xc was still checking it with #ifdef. Caused horrible space noises to be emitted from the DACs in my project which does not have I2S_MODE_TDM set.

Previous DoDsdDopCheck fix still didn't compile because p_dsd_clk did not exist. Fixed here.
