### PR TITLE
Update input audio buffer handling in decouple.xc

### DIFF
--- a/lib_xua/src/core/buffer/decouple/decouple.xc
+++ b/lib_xua/src/core/buffer/decouple/decouple.xc
@@ -594,6 +594,9 @@ __builtin_unreachable();
             aud_data_remaining_to_device = 0;
         }
 
+        /* move read pointer up to next word boundary */
+        g_aud_from_host_rdptr = (g_aud_from_host_rdptr + 3) & ~0x3;
+
         /* Wrap read pointer */
         if (g_aud_from_host_rdptr >= aud_from_host_fifo_end)
         {


### PR DESCRIPTION
 - Ensure that the total samples to write into audioBuffIn will fit to prevent
   buffer overruns.
 - Add additional critical sections on buffer pointer manipulation to prevent
   race conditions.