### PR TITLE
Handle libusb_control_transfer errors from dfu_upload

### DIFF
--- a/host/xmosdfu/xmosdfu.cpp
+++ b/host/xmosdfu/xmosdfu.cpp
@@ -311,6 +311,11 @@ int read_dfu_image(char *file)
         {
             break;
         }
+        else if (numBytes < 0)
+        {
+            fprintf(stderr,"dfu_upload error (%d)\n", numBytes);
+            break;
+        }
         fwrite(block_data, 1, block_size, outFile);
         block_count++;
     }


### PR DESCRIPTION
This should fix the one where an upload operation on an unresponsive device results in xmosdfu going into an endless loop of control requests

I filed #42 so we can go back and add handling for other instances of libusb calls