### PR TITLE
Allow nullable c_out in DoSampleTransfer() 

### DIFF
--- a/lib_xua/src/core/audiohub/xua_audiohub.xc
+++ b/lib_xua/src/core/audiohub/xua_audiohub.xc
@@ -90,7 +90,7 @@ unsigned dsdMode = DSD_MODE_OFF;
 #endif
 
 #pragma unsafe arrays
-static inline unsigned DoSampleTransfer(chanend c_out, const int readBuffNo, const unsigned underflowWord)
+static inline unsigned DoSampleTransfer(chanend ?c_out, const int readBuffNo, const unsigned underflowWord)
 {
     if(XUA_USB_EN)
     {


### PR DESCRIPTION
This is needed for applications with XUA_USB_EN=0.


With this change all the stereo builds in sw_vocalfusion are compiling and running. 