### PR TITLE
Fix xs1.h not included when XUA_USB_EN=0

### DIFF
--- a/lib_xua/api/xua_audiohub.h
+++ b/lib_xua/api/xua_audiohub.h
@@ -5,6 +5,7 @@
 #if __XC__
 
 #include "xccompat.h"
+#include "xs1.h"
 
 #if XUA_USB_EN
 #include "dfu_interface.h"


### PR DESCRIPTION
When XUA_USB_EN=0, xua_audiohub doesn't include dfu_interface.h. dfu_interface.h includes xud_device.h, which includes xud.h, which includes xs1.h. Without xs1.h the clock, port, etc. types are not available so compilation fails.

This issue was discovered when compiling XUA without xua main as part of an audio pipelines build using i2s only.