### PR TITLE
Update Jenkins shared library

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('xmos_jenkins_shared_library@v0.14.2') _
+@Library('xmos_jenkins_shared_library@v0.16.2') _
 
 getApproval()
 


### PR DESCRIPTION
This repo is still using an old version that is sensitive to brew upgrades of the python version
seen here: http://srv-bri-jcim0:8080/view/sw_xvf3510_develop/job/XMOS/job/lib_xua/job/develop/404/

I have attempted to manually fix this issue as it appeared on bench0 but the upgraded xjsl should avoid it entirely.