### PR TITLE
Use v1.2.0 release of XUD

### DIFF
--- a/lib_xua/module_build_info
+++ b/lib_xua/module_build_info
@@ -2,7 +2,7 @@ VERSION = 2.0.0
 
 DEPENDENT_MODULES = lib_logging(>=3.0.0) \
                     lib_xassert(>=4.0.0) \
-                    lib_xud(>=2.0.0) \
+                    lib_xud(>=1.2.0) \
                     lib_spdif(>=4.0.0) \
                     lib_mic_array(>=4.0.0)
 


### PR DESCRIPTION
Use the latest public release of lib_xud, v1.2.0.  This release supports XS2 and does not contain the changes needed for XS3 which have had minimal XS2 testing.