### PR TITLE
Add C and XC specific declarations of hidGetReportItem()

### DIFF
--- a/lib_xua/src/hid/xua_hid_report_descriptor.h
+++ b/lib_xua/src/hid/xua_hid_report_descriptor.h
@@ -111,7 +111,11 @@ size_t hidGetReportDescriptorLength( void );
  * @retval \c HID_STATUS_BAD_LOCATION   The \a bit or \a byte arguments specify a location outside
  *                                      of the HID Report
  */
+#if defined(__XC__)
+unsigned hidGetReportItem( const unsigned byte, const unsigned bit, unsigned char* unsafe const page, unsigned char* unsafe const header, unsigned char* unsafe const data);
+#else
 unsigned hidGetReportItem( const unsigned byte, const unsigned bit, unsigned char* const page, unsigned char* const header, unsigned char data[]);
+#endif
 
 /**
  * @brief Get the length of the HID Report


### PR DESCRIPTION
To make `hidGetReportItem()`, which returns values through argument pointers and is defined in a C file, callable from an XC file, I have had to declare it separately for the two languages.  Given my limited experience in writing C files callable from XC, I'm unsure if I have used the best technique.

You can find the call to `hidGetReportItem()` from XC in `gpio_command_handler()`, gpio_control.xc in sw_xvf3510.  The definition of `hidGetReportItem()` appears in hid_report_descriptor.c in lib_xua.