### PR TITLE
Revert the dependency on lib_xud to v1.2.0

### DIFF
--- a/lib_xua/module_build_info
+++ b/lib_xua/module_build_info
@@ -2,7 +2,7 @@ VERSION = 2.0.0
 
 DEPENDENT_MODULES = lib_logging(>=3.0.0) \
                     lib_xassert(>=4.0.0) \
-                    lib_xud(>=2.0.0) \
+                    lib_xud(>=1.2.0) \
                     lib_spdif(>=4.0.0) \
                     lib_mic_array(>=4.0.0)
 


### PR DESCRIPTION
XVF3510 uses XUD v1.2.0 to avoid the new XUD functionality that has not yet been fully tested on xCore-200.