### PR TITLE
Prepare release v2.0.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 lib_xua Change Log
 ==================
 
+2.0.1
+-----
+
+  * CHANGED:   Reverted dependency on lib_xud to v1.2.0 for use by XVF3510
+
 2.0.0
 -----
 

--- a/lib_xua/module_build_info
+++ b/lib_xua/module_build_info
@@ -1,4 +1,4 @@
-VERSION = 2.0.0
+VERSION = 2.0.1
 
 DEPENDENT_MODULES = lib_logging(>=3.0.0) \
                     lib_xassert(>=4.0.0) \


### PR DESCRIPTION
This pull request changes the version of lib_xud upon which lib_xua depends.  Specifically, it reverts the version from >= v2.0.0 to >= v1.2.0.  This reversion allows XVF3510, which uses lib_xud at v1.2.0, to build successfully.  XVF3510's use of an older version of lib_xud is still in place because v2.0.0 of that repository has not been fully tested for use with XS2 parts, including the ones used by XVF3510.