### PR TITLE
Update report descriptor for the multi-report test

### DIFF
--- a/tests/xua_unit_tests/src/test_multi_report/hid_report_descriptor.h
+++ b/tests/xua_unit_tests/src/test_multi_report/hid_report_descriptor.h
@@ -12,7 +12,7 @@
 
 /*
  * Define non-configurable items in the HID Report descriptor.
- * (These are short items as the location field isn't relevant for them)
+ * The value id and location fields for non-configurable items does not matter.
  */
 static const USB_HID_Short_Item_t hidCollectionApplication  = {
     .header = HID_REPORT_SET_HEADER(1, HID_REPORT_ITEM_TYPE_MAIN, HID_REPORT_ITEM_TAG_COLLECTION),
@@ -20,9 +20,6 @@ static const USB_HID_Short_Item_t hidCollectionApplication  = {
 static const USB_HID_Short_Item_t hidCollectionEnd          = {
     .header = HID_REPORT_SET_HEADER(0, HID_REPORT_ITEM_TYPE_MAIN, HID_REPORT_ITEM_TAG_END_COLLECTION),
     .data = { 0x00, 0x00 } };
-static const USB_HID_Short_Item_t hidCollectionLogical      = {
-    .header = HID_REPORT_SET_HEADER(1, HID_REPORT_ITEM_TYPE_MAIN, HID_REPORT_ITEM_TAG_COLLECTION),
-    .data = { 0x02, 0x00 } };
 
 static const USB_HID_Short_Item_t hidInputConstArray        = {
     .header = HID_REPORT_SET_HEADER(1, HID_REPORT_ITEM_TYPE_MAIN, HID_REPORT_ITEM_TAG_INPUT),
@@ -57,13 +54,28 @@ static const USB_HID_Short_Item_t hidReportSize1            = {
     .header = HID_REPORT_SET_HEADER(1, HID_REPORT_ITEM_TYPE_GLOBAL, HID_REPORT_ITEM_TAG_REPORT_SIZE),
     .data = { 0x01, 0x00 } };
 
-static const USB_HID_Short_Item_t hidUsageConsumerControl   = {
+static const USB_HID_Short_Item_t hidUsagePageGenericDesktop  = { 
+    .header = HID_REPORT_SET_HEADER(1, HID_REPORT_ITEM_TYPE_GLOBAL, HID_REPORT_ITEM_TAG_USAGE_PAGE),
+    .data = { USB_HID_USAGE_PAGE_ID_GENERIC_DESKTOP, 0x00 }};
+static const USB_HID_Short_Item_t hidUsagePageConsumerControl = {
+    .header = HID_REPORT_SET_HEADER(1, HID_REPORT_ITEM_TYPE_GLOBAL, HID_REPORT_ITEM_TAG_USAGE_PAGE),
+    .data = { USB_HID_USAGE_PAGE_ID_CONSUMER, 0x00 }};
+static const USB_HID_Short_Item_t hidUsagePageTelephony       = {
+    .header = HID_REPORT_SET_HEADER(1, HID_REPORT_ITEM_TYPE_GLOBAL, HID_REPORT_ITEM_TAG_USAGE_PAGE),
+    .data = { USB_HID_USAGE_PAGE_ID_TELEPHONY_DEVICE, 0x00 }};
+
+static const USB_HID_Short_Item_t hidUsageKeyboard            = {
+    .header = HID_REPORT_SET_HEADER(1, HID_REPORT_ITEM_TYPE_LOCAL, HID_REPORT_ITEM_TAG_USAGE),
+    .data = { 0x06, 0x00 }};
+static const USB_HID_Short_Item_t hidUsageConsumerControl     = {
     .header = HID_REPORT_SET_HEADER(1, HID_REPORT_ITEM_TYPE_LOCAL, HID_REPORT_ITEM_TAG_USAGE),
     .data = { 0x01, 0x00 } };
+static const USB_HID_Short_Item_t hidUsageTelephonyHeadset    = {
+    .header = HID_REPORT_SET_HEADER(1, HID_REPORT_ITEM_TYPE_LOCAL, HID_REPORT_ITEM_TAG_USAGE),
+    .data = { 0x05, 0x00 }};
 
 /*
  * Define the HID Report Descriptor Item, Usage Page, Report ID and length for each HID Report
- * For internal purposes, a report element with ID of 0 must be included if report IDs are not being used.
  */
 static const USB_HID_Short_Item_t hidReportId1  = {
     .header = HID_REPORT_SET_HEADER(1, HID_REPORT_ITEM_TYPE_GLOBAL, HID_REPORT_ITEM_TAG_REPORT_ID),
@@ -93,6 +105,9 @@ static const USB_HID_Report_Element_t hidReportTelephony    = {
     .location = HID_REPORT_SET_LOC( USB_HID_REPORT_ID_TELEPHONY, 1, 0, 0 )
 };
 
+/*
+ * Define configurable elements in the HID Report descriptor.
+ */
 static USB_HID_Report_Element_t hidUsageReport1Byte0Bit0    = {
     .item.header = HID_REPORT_SET_HEADER(1, HID_REPORT_ITEM_TYPE_LOCAL, HID_REPORT_ITEM_TAG_USAGE),
     .item.data = { 0x17, 0x00 },
@@ -186,8 +201,7 @@ static USB_HID_Report_Element_t* const hidConfigurableElements[] = {
 };
 
 /*
- * List HID Reports, one per Report ID. This should be a usage page item with the locator filled out with ID and size
- * If not using report IDs - still have one with report ID 0
+ * List HID Reports, one per Report ID.
  */
 static const USB_HID_Report_Element_t* const hidReports[] = {
     &hidReportKeyboard,
@@ -199,72 +213,74 @@ static const USB_HID_Report_Element_t* const hidReports[] = {
  * List all items in the HID Report descriptor.
  */
 static const USB_HID_Short_Item_t* const hidReportDescriptorItems[] = {
-    &(hidReportConsumer.item),
+    &hidUsagePageGenericDesktop,
+    &hidUsageKeyboard,
+    &hidReportSize1,
+    &hidLogicalMinimum0,
+    &hidCollectionApplication,      // Report 1
+        &hidReportId1,
+        &(hidReportKeyboard.item),
+        &hidLogicalMaximum1,
+        &hidReportCount1,
+        &(hidUsageReport1Byte0Bit0.item),
+        &hidInputDataVar,
+        &hidLogicalMaximum0,
+        &hidInputConstArray,
+        &hidLogicalMaximum1,
+        &(hidUsageReport1Byte0Bit2.item),
+        &hidInputDataVar,
+        &(hidUsageReport1Byte0Bit3.item),
+        &hidInputDataVar,
+        &hidLogicalMaximum0,
+        &hidReportCount4,
+        &hidInputConstArray,
+    &hidCollectionEnd,
+    &hidUsagePageConsumerControl,
     &hidUsageConsumerControl,
-    &hidCollectionApplication,
-        &hidReportSize1,
-        &hidLogicalMinimum0,
-        &hidCollectionLogical,      // Report 1
-            &hidReportId1,
-            &(hidReportKeyboard.item),
-            &hidLogicalMaximum1,
-            &hidReportCount1,
-            &(hidUsageReport1Byte0Bit0.item),
-            &hidInputDataVar,
-            &hidLogicalMaximum0,
-            &hidInputConstArray,
-            &hidLogicalMaximum1,
-            &(hidUsageReport1Byte0Bit2.item),
-            &hidInputDataVar,
-            &(hidUsageReport1Byte0Bit3.item),
-            &hidInputDataVar,
-            &hidLogicalMaximum0,
-            &hidReportCount4,
-            &hidInputConstArray,
-        &hidCollectionEnd,
-        &hidCollectionLogical,      // Report 2
-            &hidReportId2,
-            &(hidReportConsumer.item),
-            &hidLogicalMaximum1,
-            &hidReportCount1,
-            &(hidUsageReport2Byte0Bit0.item),
-            &hidInputDataVar,
-            &(hidUsageReport2Byte0Bit1.item),
-            &hidInputDataVar,
-            &(hidUsageReport2Byte0Bit2.item),
-            &hidInputDataVar,
-            &hidLogicalMaximum0,
-            &hidInputConstArray,
-            &hidLogicalMaximum1,
-            &(hidUsageReport2Byte0Bit4.item),
-            &hidInputDataVar,
-            &hidLogicalMaximum0,
-            &hidInputConstArray,
-            &hidLogicalMaximum1,
-            &(hidUsageReport2Byte0Bit6.item),
-            &hidInputDataVar,
-            &(hidUsageReport2Byte0Bit7.item),
-            &hidInputDataVar,
-            &hidLogicalMaximum0,
-            &hidReportCount7,
-            &hidInputConstArray,
-            &hidLogicalMaximum1,
-            &hidReportCount1,
-            &(hidUsageReport2Byte1Bit7.item),
-            &hidInputDataVar,
-        &hidCollectionEnd,
-        &hidCollectionLogical,      // Report 3
-            &hidReportId3,
-            &(hidReportTelephony.item),
-            &(hidUsageReport3Byte0Bit0.item),
-            &hidInputDataVar,
-            &(hidUsageReport3Byte0Bit1.item),
-            &hidInputDataVar,
-            &hidLogicalMaximum0,
-            &hidReportCount6,
-            &hidInputConstArray,
-        &hidCollectionEnd,
-    &hidCollectionEnd
+    &hidCollectionApplication,      // Report 2
+        &hidReportId2,
+        &(hidReportConsumer.item),
+        &hidLogicalMaximum1,
+        &hidReportCount1,
+        &(hidUsageReport2Byte0Bit0.item),
+        &hidInputDataVar,
+        &(hidUsageReport2Byte0Bit1.item),
+        &hidInputDataVar,
+        &(hidUsageReport2Byte0Bit2.item),
+        &hidInputDataVar,
+        &hidLogicalMaximum0,
+        &hidInputConstArray,
+        &hidLogicalMaximum1,
+        &(hidUsageReport2Byte0Bit4.item),
+        &hidInputDataVar,
+        &hidLogicalMaximum0,
+        &hidInputConstArray,
+        &hidLogicalMaximum1,
+        &(hidUsageReport2Byte0Bit6.item),
+        &hidInputDataVar,
+        &(hidUsageReport2Byte0Bit7.item),
+        &hidInputDataVar,
+        &hidLogicalMaximum0,
+        &hidReportCount7,
+        &hidInputConstArray,
+        &hidLogicalMaximum1,
+        &hidReportCount1,
+        &(hidUsageReport2Byte1Bit7.item),
+        &hidInputDataVar,
+    &hidCollectionEnd,
+    &hidUsagePageTelephony,
+    &hidUsageTelephonyHeadset,
+    &hidCollectionApplication,      // Report 3
+        &hidReportId3,
+        &(hidReportTelephony.item),
+        &(hidUsageReport3Byte0Bit0.item),
+        &hidInputDataVar,
+        &(hidUsageReport3Byte0Bit1.item),
+        &hidInputDataVar,
+        &hidLogicalMaximum0,
+        &hidReportCount6,
+        &hidInputConstArray,
+    &hidCollectionEnd,
 };
 
 /*


### PR DESCRIPTION
Update the HID Report Descriptor to more closely match one known to work in practice with real operating systems.