### PR TITLE
Fix ifdefs/endifs in ep_buffer.xc

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ UNRELEASED
 ----------
 
   * CHANGED:   Exclude HID Report functions unless the HID feature is enabled
+  * FIXED:     Incorrect conditional compilation of HID report code
 
 3.1.0
 -----

--- a/lib_xua/src/core/buffer/ep/ep_buffer.xc
+++ b/lib_xua/src/core/buffer/ep/ep_buffer.xc
@@ -1104,6 +1104,9 @@ void XUA_Buffer_Ep(register chanend c_aud_out,
                         break;
                 }
                 break;
+#endif  // if IAP_EA_NATIVE_TRANS
+
+#endif  // ifdef IAP
 
             default:
 #if ( 0 < HID_CONTROLS )
@@ -1125,9 +1128,6 @@ void XUA_Buffer_Ep(register chanend c_aud_out,
 #endif
                 break;
                 //::
-#endif
-
-#endif
 
 
         }


### PR DESCRIPTION
These endifs were put in the wrong place so the HID code in the default case wasn't always being compiled.

The Jenkins failure is just unstable for the changelog check.