### PR TITLE
Fix insufficient buffering in decouple

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,7 @@ lib_xua Change Log
   * FIXED:     Incorrect conditional compilation of HID report code
   * FIXED:     Input/output descriptors written when input/output not enabled.
     (Audio class 1.0 mode using XUA_USB_DESCRIPTOR_OVERWRITE_RATE_RES)
+  * FIXED:     Insufficient buffering of input packets
 
   * Changes to dependencies:
 


### PR DESCRIPTION
I've run a lot of tests with the sw_usb_audio using this change and I haven't seen any packets of zeroes on S/PDIF, and I haven't seen any other new issues from this change.