### PR TITLE
Revert TDM ADC clocking change from commit a1946f3

### DIFF
--- a/lib_xua/src/core/ports/audioports.xc
+++ b/lib_xua/src/core/ports/audioports.xc
@@ -84,8 +84,8 @@ void ConfigAudioPorts(
     {
         for(int i = 0; i < I2S_WIRES_ADC; i++)
         {
-            //set_port_sample_delay(p_i2s_adc[i]);
-            //set_pad_delay(p_i2s_adc[i], 4);
+            set_port_sample_delay(p_i2s_adc[i]);
+            set_pad_delay(p_i2s_adc[i], 4);
         }
     }
 #endif


### PR DESCRIPTION
Successful run of USB Audio: http://srv-bri-jcim0:8080/blue/organizations/jenkins/XMOS%2Fsw_usb_audio/detail/develop/782/pipeline

The change favours the 316 board, so "tdm8" USB Audio configs on the 216 board that fail will be moved into the "build-tested only" group.