### PR TITLE
Mixer Host App: Multi device error handeling & device ID agnostic

### DIFF
--- a/host_usb_mixer_control/usb_mixer.cpp
+++ b/host_usb_mixer_control/usb_mixer.cpp
@@ -650,7 +650,7 @@ static int find_xmos_device(unsigned int id)
     libusb_device **devs;
 
     libusb_get_device_list(NULL, &devs);
-    while ((dev = devs[i++]) != NULL) 
+    while ((dev = devs[i]) != NULL) 
     {
         struct libusb_device_descriptor desc;
         libusb_get_device_descriptor(dev, &desc);
@@ -663,6 +663,7 @@ static int find_xmos_device(unsigned int id)
                 id = i;
             }
         }
+        i++;
     }
     if (found == -1) {
         fprintf(stderr, "ERROR :: No device detected\n");
@@ -703,7 +704,7 @@ static int find_xmos_device(unsigned int id)
     {
 #if defined(__APPLE__)
         libusb_config_descriptor *config_desc = NULL;
-        libusb_get_active_config_descriptor(dev, &config_desc);
+        libusb_get_active_config_descriptor(devs[id], &config_desc);
         if (config_desc != NULL) 
         {
             //unsigned int num_mixers_found = 0;


### PR DESCRIPTION
Removed the requirement to maintain a list of supported device ID's from the macOS code. Debug devices are ignored based on how their ID's are grouped.

Behaviour change: When multiple potentially compatible devices are connected the host app will now inform the user instead of connecting to the first one it finds.