### PR TITLE
SPDIF api fix

### DIFF
--- a/lib_xua/doc/rst/feat_spdif_rx.rst
+++ b/lib_xua/doc/rst/feat_spdif_rx.rst
@@ -20,11 +20,11 @@ Finally, a channel for the output samples must be declared, note, this should be
 
 The S/PDIF receiver should be called on the appropriate tile::
 
-    SpdifReceive(p_spdif_rx, c_spdif_rx, 1, clk_spd_rx);
+    spdif_rx(c_spdif_rx,p_spdif_rx,clk_spd_rx,192000);
 
 .. note:: 
 
-    It is recomended to use the value 1 for the ``initial_divider`` parameter
+    It is recomended to use the value 192000 for the ``sample_freq_estimate`` parameter
 
 With the steps above an S/PDIF stream can be captured by the xCORE. To be functionally useful the audio
 master clock must be able to synchronise to this external digital stream. Additionally, the host can be 

--- a/lib_xua/src/core/main.xc
+++ b/lib_xua/src/core/main.xc
@@ -142,7 +142,7 @@ on stdcore[XUD_TILE] : buffered in port:32 p_adat_rx        = PORT_ADAT_IN;
 #endif
 
 #if (XUA_SPDIF_RX_EN)
-on tile[XUD_TILE] : buffered in port:4 p_spdif_rx           = PORT_SPDIF_IN;
+on tile[XUD_TILE] : in port p_spdif_rx                      = PORT_SPDIF_IN;
 #endif
 
 #if (XUA_SPDIF_RX_EN) || (XUA_ADAT_RX_EN) || (XUA_SYNCMODE == XUA_SYNCMODE_SYNC)
@@ -685,7 +685,7 @@ int main()
         on tile[XUD_TILE]:
         {
             thread_speed();
-            SpdifReceive(p_spdif_rx, c_spdif_rx, 1, clk_spd_rx);
+            spdif_rx(c_spdif_rx,p_spdif_rx,clk_spd_rx,192000);
         }
 #endif
 


### PR DESCRIPTION
lib_xua used the old header files in lib_spdif rather than the api header file.

- the api header was missing one of the rx functions so this wont build until the PR adding it to the api file is merged