### PR TITLE
Fix memory corruption during initialisation of mixer weights

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 lib_xua Change Log
 ==================
 
+UNRELEASED
+----------
+
+  * FIXED:     Memory corruption during initialisation of mixer weights
+
 3.4.0
 -----
 

--- a/lib_xua/src/core/endpoint0/xua_endpoint0.c
+++ b/lib_xua/src/core/endpoint0/xua_endpoint0.c
@@ -275,15 +275,10 @@ void InitLocalMixerState()
     }
 
     /* Configure default connections */
-    // TODO this should be a loop using defines.
-    mixer1Weights[0] = 0;
-    mixer1Weights[9] = 0;
-    mixer1Weights[18] = 0;
-    mixer1Weights[27] = 0;
-    mixer1Weights[36] = 0;
-    mixer1Weights[45] = 0;
-    mixer1Weights[54] = 0;
-    mixer1Weights[63] = 0;
+    for (int i = 0; i < MAX_MIX_COUNT; i++)
+    {
+        mixer1Weights[(i * MAX_MIX_COUNT) + i] = 0;
+    }
 
 #if NUM_USB_CHAN_OUT > 0
     /* Setup up audio output channel mapping */


### PR DESCRIPTION
Fixes [sw_usb_audio#152](https://github.com/xmos/sw_usb_audio/issues/152)