### PR TITLE
Use bat not sh for windows builds on Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -153,8 +153,8 @@ pipeline {
                   withVS() {
                     bat 'msbuild host_usb_mixer_control.vcxproj /property:Configuration=Release /property:Platform=x64'
                   }
-                  sh 'mkdir Win/x64'
-                  sh 'mv bin/Release/x64/host_usb_mixer_control.exe Win/x64/xmos_mixer.exe'
+                  bat 'mkdir Win\\x64'
+                  bat 'mv bin/Release/x64/host_usb_mixer_control.exe Win/x64/xmos_mixer.exe'
                   archiveArtifacts artifacts: "Win/x64/xmos_mixer.exe", fingerprint: true
               }
             }


### PR DESCRIPTION
This was causing an issue where the windows workspaces could not be cleared.