### PR TITLE
Respect I2S_CHANS_PER_FRAME when calculating bit-clock rates

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 lib_xua Change Log
 ==================
 
+UNRELEASED
+----------
+
+  * FIXED:     Respect I2S_CHANS_PER_FRAME when calculating bit-clock rates
+
 3.5.0
 -----
 

--- a/lib_xua/src/core/audiohub/xua_audiohub.xc
+++ b/lib_xua/src/core/audiohub/xua_audiohub.xc
@@ -715,13 +715,7 @@ void XUA_AudioHub(chanend ?c_aud, clock ?clk_audio_mclk, clock ?clk_audio_bclk,
         /* Calculate master clock to bit clock (or DSD clock) divide for current sample freq
          * e.g. 11.289600 / (176400 * 64)  = 1 */
         {
-            unsigned numBits = XUA_I2S_N_BITS * 2;
-
-            if(XUA_PCM_FORMAT == XUA_PCM_FORMAT_TDM)
-            {
-                /* TDM has 8 channels */
-                numBits *= 4;
-            }
+            unsigned numBits = XUA_I2S_N_BITS * I2S_CHANS_PER_FRAME;
 
 #if (DSD_CHANS_DAC > 0)
             if(dsdMode == DSD_MODE_DOP)


### PR DESCRIPTION
Required to make something like TDM16 operate as expected