### PR TITLE
Removed usage of unused internal DFU commands

### DIFF
--- a/lib_xua/api/xua_conf_default.h
+++ b/lib_xua/api/xua_conf_default.h
@@ -1249,8 +1249,6 @@ enum USBEndpointNumber_Out
 #endif /* __ASSEMBLER__ */
 
 #define AUDIO_STOP_FOR_DFU                (0x12345678)
-#define AUDIO_START_FROM_DFU              (0x87654321)
-#define AUDIO_REBOOT_FROM_DFU             (0xa5a5a5a5)
 
 /* Result of db_to_mult(MAX_VOLUME, 8, 29) */
 #define MAX_VOLUME_MULT                   (0x20000000)

--- a/lib_xua/src/core/audiohub/xua_audiohub.xc
+++ b/lib_xua/src/core/audiohub/xua_audiohub.xc
@@ -806,7 +806,7 @@ void XUA_AudioHub(chanend ?c_aud, clock ?clk_audio_mclk, clock ?clk_audio_bclk,
         {
             /* TODO wait for good mclk instead of delay */
             /* No delay for DFU modes */
-            if (((curSamFreq / AUD_TO_USB_RATIO) != AUDIO_REBOOT_FROM_DFU) && ((curSamFreq / AUD_TO_USB_RATIO) != AUDIO_STOP_FOR_DFU) && command)
+            if (((curSamFreq / AUD_TO_USB_RATIO) != AUDIO_STOP_FOR_DFU) && command)
             {
 #if 0
                 /* User should ensure MCLK is stable in AudioHwConfig */
@@ -916,13 +916,9 @@ void XUA_AudioHub(chanend ?c_aud, clock ?clk_audio_mclk, clock ?clk_audio_bclk,
 #else
                         dummy_deliver(c_aud, command);
 #endif
+                        /* Note, we do not expect to reach here */
                         curSamFreq = inuint(c_aud);
-
-                        if (curSamFreq == AUDIO_START_FROM_DFU)
-                        {
-                            outct(c_aud, XS1_CT_END);
-                            break;
-                        }
+                        outct(c_aud, XS1_CT_END);
                     }
                 }
 #endif


### PR DESCRIPTION
During investigation of a customer DFU issue I noted there were some old, internal, DFU commands that were no longer used. This PR removes them.