### PR TITLE
Tidy up QUAD_SPI_FLASH define (now XUA_QUAD_SPI_FLASH)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,8 @@ HEAD
 
   * RESOLVED:  Output volume control not enabled by default when MIXER disabled
   * RESOLVED:  Full 32bit result of volume processing not calculated when required
-  * RESOVED:   Input stream sending an erroneous zero-length packet when exiting underflow state
+  * RESOLVED:  Input stream sending an erroneous zero-length packet when exiting underflow state
+  * CHANGED:   QUAD_SPI_FLASH replaced by XUA_QUAD_SPI_FLASH (default: 1)
 
 3.5.1
 -----

--- a/lib_xua/api/xua_conf_default.h
+++ b/lib_xua/api/xua_conf_default.h
@@ -241,7 +241,9 @@
 #endif
 
 /**
- * @brief Default device sample frequency. A safe default should be used. Default: MIN_FREQ
+ * @brief Default device sample frequency. A safe default should be used.
+ *
+ * Default: MIN_FREQ
  */
 #ifndef DEFAULT_FREQ
 #define DEFAULT_FREQ             (MIN_FREQ)
@@ -250,7 +252,9 @@
 /* Audio Class Defines */
 
 /**
- * @brief USB Audio Class Version. Default: 2 (Audio Class version 2.0)
+ * @brief USB Audio Class Version.
+ *
+ * Default: 2 (Audio Class version 2.0)
  */
 #ifndef AUDIO_CLASS
 #define AUDIO_CLASS 2
@@ -293,7 +297,9 @@
 /* Feature defines */
 
 /**
- * @brief Number of PDM microphones in the design. Default: None
+ * @brief Number of PDM microphones in the design.
+ *
+ * Default: None
  */
 #ifndef XUA_NUM_PDM_MICS
 #define XUA_NUM_PDM_MICS            (0)
@@ -310,14 +316,18 @@
 #endif
 
 /**
- * @brief Size of a frame of microphone data samples. Default: 1
+ * @brief Size of a frame of microphone data samples.
+ *
+ * Default: 1
  */
 #ifndef XUA_MIC_FRAME_SIZE
 #define XUA_MIC_FRAME_SIZE      (1)
 #endif
 
 /**
- * @brief Enable MIDI functionality including buffering, descriptors etc. Default: DISABLED
+ * @brief Enable MIDI functionality including buffering, descriptors etc.
+ *
+ * Default: 0 (Disabled)
  */
 #ifndef MIDI
 #define MIDI                    (0)
@@ -351,7 +361,9 @@
 #endif
 
 /**
- * @brief Enables ADAT Tx. Default: 0 (Disabled)
+ * @brief Enables ADAT Tx.
+ *
+ * Default: 0 (Disabled)
  */
 #ifndef XUA_ADAT_TX_EN
 #define XUA_ADAT_TX_EN           (0)
@@ -367,14 +379,18 @@
 #endif
 
 /**
- * @brief Enables SPDIF Rx. Default: 0 (Disabled)
+ * @brief Enables SPDIF Rx.
+ *
+ * Default: 0 (Disabled)
  */
 #ifndef XUA_SPDIF_RX_EN
 #define XUA_SPDIF_RX_EN       (0)
 #endif
 
 /**
- * @brief Enables ADAT Rx. Default: 0 (Disabled)
+ * @brief Enables ADAT Rx.
+ *
+ * Default: 0 (Disabled)
  */
 #ifndef XUA_ADAT_RX_EN
 #define XUA_ADAT_RX_EN        (0)
@@ -432,9 +448,18 @@
  * Default: 1 (Enabled)
  */
 #if !defined(XUA_DFU_EN)
-#define XUA_DFU_EN                   (1)
+#define XUA_DFU_EN                  (1)
 #elif defined(XUA_DFU_EN) && (XUA_DFU_EN == 0)
 #undef XUA_DFU_EN
+#endif
+
+/**
+ * @brief Use a QSPI (rather than SPI) flash for DFU (and boot)
+ *
+ * Default: 1 (True i.e use QSPI flash)
+*/
+#if !defined(XUA_QUAD_SPI_FLASH)
+#define XUA_QUAD_SPI_FLASH          (1)
 #endif
 
 /**
@@ -445,7 +470,7 @@
  * Default 0 (Disabled)
  */
 #ifndef HID_CONTROLS
-#define HID_CONTROLS       (0)
+#define HID_CONTROLS                (0)
 #endif
 
 /**

--- a/lib_xua/src/dfu/flash_interface.c
+++ b/lib_xua/src/dfu/flash_interface.c
@@ -1,4 +1,4 @@
-// Copyright 2011-2021 XMOS LIMITED.
+// Copyright 2011-2023 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 #include <xs1.h>
 #include <flash.h>

--- a/lib_xua/src/dfu/flash_interface.c
+++ b/lib_xua/src/dfu/flash_interface.c
@@ -72,7 +72,7 @@ int flash_cmd_init(void)
         return 1;
     }
 
-#ifndef QUAD_SPI_FLASH
+#if (!XUA_QUAD_SPI_FLASH)
     // Disable flash protection
     fl_setProtection(0);
 #endif

--- a/lib_xua/src/dfu/flashlib_user.c
+++ b/lib_xua/src/dfu/flashlib_user.c
@@ -1,4 +1,4 @@
-// Copyright 2012-2021 XMOS LIMITED.
+// Copyright 2012-2023 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 #include "xua.h"
 #if (XUA_DFU_EN == 1)

--- a/lib_xua/src/dfu/flashlib_user.c
+++ b/lib_xua/src/dfu/flashlib_user.c
@@ -5,7 +5,7 @@
 #include "uac_hwresources.h"
 #include <xs1.h>
 #include <xclib.h>
-#ifdef QUAD_SPI_FLASH
+#if (XUA_QUAD_SPI_FLASH)
 #include <quadflashlib.h>
 #else
 #include <flashlib.h>
@@ -20,7 +20,7 @@
 
 #ifdef DFU_FLASH_DEVICE
 
-#ifdef QUAD_SPI_FLASH
+#if (XUA_QUAD_SPI_FLASH)
 /* Using specified flash device rather than all supported in tools */
 fl_QuadDeviceSpec flash_devices[] = {DFU_FLASH_DEVICE};
 #else
@@ -29,7 +29,7 @@ fl_DeviceSpec flash_devices[] = {DFU_FLASH_DEVICE};
 #endif
 #endif
 
-#ifdef QUAD_SPI_FLASH
+#if (XUA_QUAD_SPI_FLASH)
 /*
 typedef struct {
       out port qspiCS;
@@ -60,7 +60,7 @@ fl_PortHolderStruct p_flash =
 int flash_cmd_enable_ports()
 {
     int result = 0;
-#ifdef QUAD_SPI_FLASH
+#if (XUA_QUAD_SPI_FLASH)
     /* Ports not shared */
 #else
     setc(p_flash.spiMISO, XS1_SETC_INUSE_OFF);
@@ -89,14 +89,14 @@ int flash_cmd_enable_ports()
 #endif
 
 #ifdef DFU_FLASH_DEVICE
-#ifdef QUAD_SPI_FLASH
+#if (XUA_QUAD_SPI_FLASH)
     result = fl_connectToDevice(&p_qflash, flash_devices, sizeof(flash_devices) / sizeof(fl_QuadDeviceSpec));
 #else
     result = fl_connectToDevice(&p_flash, flash_devices, sizeof(flash_devices) / sizeof(fl_DeviceSpec));
 #endif
 #else
     /* Use default flash list */
-#ifdef QUAD_SPI_FLASH
+#if (XUA_QUAD_SPI_FLASH)
     result = fl_connect(&p_qflash);
 #else
     result = fl_connect(&p_flash);
@@ -117,7 +117,7 @@ int flash_cmd_disable_ports()
 {
     fl_disconnect();
 
-#ifndef QUAD_SPI_FLASH
+#if (!XUA_QUAD_SPI_FLASH)
     setc(p_flash.spiMISO, XS1_SETC_INUSE_OFF);
     setc(p_flash.spiCLK, XS1_SETC_INUSE_OFF);
     setc(p_flash.spiMOSI, XS1_SETC_INUSE_OFF);


### PR DESCRIPTION
Now default behaviour since most designs now use QSPI.