### PR TITLE
Add support for XCommon CMake

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ lib_xua Change Log
 HEAD
 ----
 
+  * ADDED:     Support for XCommon CMake build system
   * RESOLVED:  Output volume control not enabled by default when MIXER disabled
   * RESOLVED:  Full 32bit result of volume processing not calculated when required
   * RESOLVED:  Input stream sending an erroneous zero-length packet when exiting underflow state

--- a/lib_xua/lib_build_info.cmake
+++ b/lib_xua/lib_build_info.cmake
@@ -1,0 +1,51 @@
+set(LIB_NAME lib_xua)
+set(LIB_VERSION 3.5.1)
+set(LIB_INCLUDES api
+                 src/core
+                 src/core/audiohub
+                 src/core/buffer/ep
+                 src/core/endpoint0
+                 src/dfu
+                 src/core/buffer/decouple
+                 src/core/clocking
+                 src/core/mixer
+                 src/core/pdm_mics
+                 src/core/ports
+                 src/core/support
+                 src/core/user
+                 src/core/user/audiostream
+                 src/core/user/hid
+                 src/core/user/hostactive
+                 src/hid
+                 src/midi)
+set(LIB_OPTIONAL_HEADERS xua_conf.h static_hid_report.h)
+set(LIB_DEPENDENT_MODULES "lib_locks"
+                          "lib_logging"
+                          "lib_mic_array(feature/xcommon_cmake)"
+                          "lib_spdif"
+                          "lib_xassert"
+                          "lib_xud"
+                          "lib_adat")
+
+set(LIB_COMPILER_FLAGS -O3 -DREF_CLK_FREQ=100 -fasm-linenum -fcomment-asm)
+
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    list(APPEND LIB_COMPILER_FLAGS -DXASSERT_ENABLE_ASSERTIONS=1
+                                   -DXASSERT_ENABLE_DEBUG=1
+                                   -DXASSERT_ENBALE_LINE_NUMBERS=1)
+else()
+    list(APPEND LIB_COMPILER_FLAGS -DXASSERT_ENABLE_ASSERTIONS=0
+                                   -DXASSERT_ENABLE_DEBUG=0
+                                   -DXASSERT_ENABLE_LINE_NUMBERS=0)
+endif()
+
+set(LIB_COMPILER_FLAGS_xua_endpoint0.c ${LIB_COMPILER_FLAGS} -Os -mno-dual-issue)
+set(LIB_COMPILER_FLAGS_xua_ep0_uacreqs.xc ${LIB_COMPILER_FLAGS} -Os -mno-dual-issue)
+set(LIB_COMPILER_FLAGS_dbcalc.xc ${LIB_COMPILER_FLAGS} -Os -mno-dual-issue)
+set(LIB_COMPILER_FLAGS_audioports.c ${LIB_COMPILER_FLAGS} -Os -mno-dual-issue)
+set(LIB_COMPILER_FLAGS_audioports.xc ${LIB_COMPILER_FLAGS} -Os -mno-dual-issue)
+set(LIB_COMPILER_FLAGS_dfu.xc ${LIB_COMPILER_FLAGS} -Os -mno-dual-issue)
+set(LIB_COMPILER_FLAGS_flash_interface.c ${LIB_COMPILER_FLAGS} -Os -mno-dual-issue)
+set(LIB_COMPILER_FLAGS_flashlib_user.c ${LIB_COMPILER_FLAGS} -Os -mno-dual-issue)
+
+XMOS_REGISTER_MODULE()


### PR DESCRIPTION
Using CMAKE_BUILD_TYPE seems to be the standard cmake way to do debug builds. I've tested with sw_usb_audio where I run `cmake -G "Unix Makefiles" -B build -D CMAKE_BUILD_TYPE=Debug` and I get the lib_xua decouple assertions compiled in.