### PR TITLE
Avoid repeating old samples when entering underflow state

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ HEAD
   * RESOLVED:  Input stream sending an erroneous zero-length packet when exiting underflow state
   * RESOLVED   Build failures when XUA_USB_EN = 0
   * RESOLVED:  Clock configuration issues when ADAT and S/PDIF receive are enabled (#352)
+  * RESOLVED:  Repeated old S/PDIF and ADAT samples when entering underflow state
   * CHANGED:   QUAD_SPI_FLASH replaced by XUA_QUAD_SPI_FLASH (default: 1)
   * CHANGED:   UserBufferManagementInit() now takes a sample rate parameter
 

--- a/lib_xua/src/core/clocking/clockgen.xc
+++ b/lib_xua/src/core/clocking/clockgen.xc
@@ -1,4 +1,4 @@
-// Copyright 2011-2023 XMOS LIMITED.
+// Copyright 2011-2024 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 #include <xs1.h>
 #include <assert.h>
@@ -718,7 +718,7 @@ void clockGen (streaming chanend ?c_spdif_rx, chanend ?c_adat_rx, client interfa
                         spdifSamps -= 2;
 
                         /* spdifSamps could go to -1 */
-                        if(spdifSamps < 0)
+                        if(spdifSamps <= 0)
                         {
                             /* We're out of S/PDIF samples, mark underflow condition */
                             spdifUnderflow = 1;
@@ -799,7 +799,7 @@ void clockGen (streaming chanend ?c_spdif_rx, chanend ?c_adat_rx, client interfa
                     }
 
                     /* adatSamps could go to -1 */
-                    if (adatSamps < 0)
+                    if (adatSamps <= 0)
                     {
                         /* we're out of ADAT samples, mark underflow condition */
                         adatUnderflow = 1;


### PR DESCRIPTION
I've been seeing some cases on Windows S/PDIF input testing where the clockGen buffer goes into underflow, and when this happens there is a discontinuity in the ramp where it jumps backwards by 64 samples as the buffer wrapped and repeated an old sample due to the `<` instead of `<=` in the comparison.