### PR TITLE
New version of g++ on Raspbian needs different linker option order

### DIFF
--- a/lib_xua/host/xmosdfu/Makefile.Pi
+++ b/lib_xua/host/xmosdfu/Makefile.Pi
@@ -6,4 +6,4 @@
 
 xmosdfu: xmosdfu.cpp
 	mkdir -p bin
-	g++ -D_GNU_SOURCE -Wall -g -o bin/xmosdfu -Ilibusb/Rasp -lusb-1.0 -x c xmosdfu.cpp -std=c99
+	g++ -D_GNU_SOURCE -Wall -g -o bin/xmosdfu -Ilibusb/Rasp -x c xmosdfu.cpp -std=c99 -lusb-1.0


### PR DESCRIPTION
Our raspberry pi Jenkins agents were updated to a newer version of Raspbian and this brought in GCC-12 instead of the previous GCC-8. Placing the `-lusb-1.0` option before the source file fails on GCC-12 but worked with GCC-8. Placing the option after the source file works on both. Jack said it's not completely unreasonable for the command-line option order to behave this way between versions.

(A better solution would be to convert the platform-specific Makefiles for xmosdfu to use CMake instead, but that's a much larger task, so this is just a quick solution to the immediate problem of failing Jenkins jobs)