### PR TITLE
Add Windows driver GUID command-line option on mixer host app

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,7 @@ HEAD
   * CHANGED:   UserBufferManagementInit() now takes a sample rate parameter
   * CHANGED:   xcore.ai targets use sigma-delta software PLL for clock recovery of
     digital Rx streams and synch USB audio by default.
+  * CHANGED:   Windows host mixer control application now requires driver GUID option
 
   * Changes to dependencies:
 

--- a/host_usb_mixer_control/usb_mixer.cpp
+++ b/host_usb_mixer_control/usb_mixer.cpp
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 XMOS LIMITED.
+// Copyright 2022-2024 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 
 #include <stdlib.h>
@@ -800,14 +800,18 @@ static int find_xmos_device(unsigned int id)
 
 // End of libusb interface functions
 
-int usb_mixer_connect() 
+#ifdef _WIN32
+int usb_mixer_connect(TCHAR guid[GUID_STR_LEN])
+#else
+int usb_mixer_connect()
+#endif
 {
     // Allocate internal storage
     usb_mixers = (usb_mixer_handle *)malloc(sizeof(usb_mixer_handle));
     memset(usb_mixers, 0, sizeof(usb_mixer_handle));
 
 #if defined(_WIN32)
-    gDrvApi.LoadByGUID(_T("{E5A2658B-817D-4A02-A1DE-B628A93DDF5D}"));
+    gDrvApi.LoadByGUID(guid);
     TUsbAudioStatus st = gDrvApi.TUSBAUDIO_EnumerateDevices();
 #endif
 

--- a/host_usb_mixer_control/usb_mixer.h
+++ b/host_usb_mixer_control/usb_mixer.h
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 XMOS LIMITED.
+// Copyright 2022-2024 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 
 #define USB_MIXER_SUCCESS 0
@@ -22,7 +22,14 @@ enum usb_chan_type {
 #define RANGE (2)
 #define MEM   (3)
 
+#ifdef _WIN32
+#include <tchar.h>
+// GUID strings are 36 characters, plus a pair of braces and NUL-termination
+#define GUID_STR_LEN (36+2+1)
+int usb_mixer_connect(TCHAR guid[GUID_STR_LEN]);
+#else
 int usb_mixer_connect();
+#endif
 int usb_mixer_disconnect();
 
 /* MIXER UNIT(s) INTERFACE */


### PR DESCRIPTION
Added a required argument on Windows before the existing mixer app options. This led to lots of changes to handle different argument indices on different platforms, but I preferred that to completely re-writing the argument parsing code to handle multiple options to a single command.