### PR TITLE
Support SMUX in clockgen software PLL updates

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ UNRELEASED
 ----------
 
   * FIXED:     Device fails to enumerate when ADAT and S/PDIF transmit are enabled
+  * FIXED:     Update software PLL at the correct rate for ADAT SMUX
   * CHANGED:   Enable only the minimum number of ADAT input formats based for the
     supported sample frequencies
 

--- a/lib_xua/src/core/clocking/clockgen.xc
+++ b/lib_xua/src/core/clocking/clockgen.xc
@@ -723,7 +723,14 @@ void clockGen ( streaming chanend ?c_spdif_rx,
                                     }
                                 }
                         }
-                        if(adatChannel == 4 || adatChannel == 8)
+
+                        /* An edge needs to be recorded/toggled in the following cases:
+                         *    smux = 0:  adatChannel = 4, 8
+                         *    smux = 1:  adatChannel = 2, 4, 6, 8
+                         *    smux = 2:  adatChannel = 1, 2, 3, 4, 5, 6, 7, 8
+                         * This is simplified to a shift-and-mask in the if-condition below.
+                         */
+                        if ((adatChannel != 0) && ((adatChannel << smux) & 3) == 0)
                         {
                             adatCounters.samples += 1;
 
@@ -764,7 +771,7 @@ void clockGen ( streaming chanend ?c_spdif_rx,
                               adatChannel = 0;
                         }
                     break;
-#endif
+#endif  // XUA_ADAT_RX_EN
 
 #if (XUA_SPDIF_RX_EN || XUA_ADAT_RX_EN)
                 /* AudioHub requests data */


### PR DESCRIPTION
Tested all sample rates with and without XUA_USE_SW_PLL for ADAT receive and there are no more underflows in the clockgen buffer. Also checked with a scope that the MCLK is now good when using the ADAT clock source.