### PR TITLE
Fix channel/ep usage when NUM_USB_CHAN_IN/OUT = 0

### DIFF
--- a/examples/AN00248_xua_example_pdm_mics/src/app_xua_simple.xc
+++ b/examples/AN00248_xua_example_pdm_mics/src/app_xua_simple.xc
@@ -38,13 +38,13 @@ clock clk_audio_mclk             = on tile[1]: XS1_CLKBLK_1;   /* Master clock *
 
 /* Endpoint type tables - informs XUD what the transfer types for each Endpoint in use and also
  * if the endpoint wishes to be informed of USB bus resets */
-XUD_EpType epTypeTableOut[]   = {XUD_EPTYPE_CTL | XUD_STATUS_ENABLE, XUD_EPTYPE_ISO};
+XUD_EpType epTypeTableOut[]   = {XUD_EPTYPE_CTL | XUD_STATUS_ENABLE};
 XUD_EpType epTypeTableIn[]    = {XUD_EPTYPE_CTL | XUD_STATUS_ENABLE, XUD_EPTYPE_ISO};
 
 int main()
 {
     /* Channels for lib_xud */
-    chan c_ep_out[2];
+    chan c_ep_out[1];
     chan c_ep_in[2];
 
     /* Channel for communicating SOF notifications from XUD to the Buffering cores */
@@ -65,7 +65,7 @@ int main()
     par
     {
         /* Low level USB device layer core */
-        on tile[1]: XUD_Main(c_ep_out, 2, c_ep_in, 2, c_sof, epTypeTableOut, epTypeTableIn, XUD_SPEED_HS, XUD_PWR_BUS);
+        on tile[1]: XUD_Main(c_ep_out, 1, c_ep_in, 2, c_sof, epTypeTableOut, epTypeTableIn, XUD_SPEED_HS, XUD_PWR_BUS);
 
         /* Endpoint 0 core from lib_xua */
         /* Note, since we are not using many features we pass in null for quite a few params.. */
@@ -82,7 +82,7 @@ int main()
            {
                 /* Buffering task - handles audio data to/from EP's and gives/gets data to/from the audio I/O core */
                 /* Note, this spawns two cores */
-                XUA_Buffer(c_ep_out[1], c_ep_in[1], c_sof, c_aud_ctl, p_for_mclk_count, c_aud);
+                XUA_Buffer(c_ep_in[1], c_sof, c_aud_ctl, p_for_mclk_count, c_aud);
 
                 /* AudioHub/IO core does most of the audio IO i.e. I2S (also serves as a hub for all audio) */
                 /* Note, since we are not using I2S we pass in null for LR and Bit clock ports and the I2S dataline ports */

--- a/examples/AN00248_xua_example_pdm_mics/src/app_xua_simple.xc
+++ b/examples/AN00248_xua_example_pdm_mics/src/app_xua_simple.xc
@@ -1,4 +1,4 @@
-// Copyright 2017-2022 XMOS LIMITED.
+// Copyright 2017-2024 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 
 /* A very simple *example* of a USB audio application (and as such is un-verified for production)

--- a/lib_xua/api/xua_buffer.h
+++ b/lib_xua/api/xua_buffer.h
@@ -30,11 +30,13 @@
  *  \param c_swpll_update       Channel connected to software PLL task. Expects master clock counts based on USB frames.
  */
 void XUA_Buffer(
+#if (NUM_USB_CHAN_OUT > 0)
             chanend c_aud_out,
+#endif
 #if (NUM_USB_CHAN_IN > 0) || defined(__DOXYGEN__)
             chanend c_aud_in,
 #endif
-#if (NUM_USB_CHAN_IN == 0) || defined (UAC_FORCE_FEEDBACK_EP)
+#if ((NUM_USB_CHAN_OUT > 0) && ((NUM_USB_CHAN == 0) || defined(UAC_FORCE_FEEDBACK_EP))) || defined(__DOXYGEN__)
             chanend c_aud_fb,
 #endif
 #if defined(MIDI) || defined(__DOXYGEN__)
@@ -64,11 +66,15 @@ void XUA_Buffer(
 #endif
         );
 
-void XUA_Buffer_Ep(chanend c_aud_out,
+void XUA_Buffer_Ep(
+
+#if (NUM_USB_CHAN_OUT > 0)
+            chanend c_aud_out,
+#endif
 #if (NUM_USB_CHAN_IN > 0) || defined(__DOXYGEN__)
             chanend c_aud_in,
 #endif
-#if (NUM_USB_CHAN_IN == 0) || defined (UAC_FORCE_FEEDBACK_EP)
+#if ((NUM_USB_CHAN_OUT > 0) && ((NUM_USB_CHAN == 0) || defined(UAC_FORCE_FEEDBACK_EP))) || defined(__DOXYGEN__)
             chanend c_aud_fb,
 #endif
 #ifdef MIDI

--- a/lib_xua/api/xua_buffer.h
+++ b/lib_xua/api/xua_buffer.h
@@ -36,7 +36,7 @@ void XUA_Buffer(
 #if (NUM_USB_CHAN_IN > 0) || defined(__DOXYGEN__)
             chanend c_aud_in,
 #endif
-#if ((NUM_USB_CHAN_OUT > 0) && ((NUM_USB_CHAN == 0) || defined(UAC_FORCE_FEEDBACK_EP))) || defined(__DOXYGEN__)
+#if ((NUM_USB_CHAN_OUT > 0) && ((NUM_USB_CHAN_IN == 0) || defined(UAC_FORCE_FEEDBACK_EP))) || defined(__DOXYGEN__)
             chanend c_aud_fb,
 #endif
 #if defined(MIDI) || defined(__DOXYGEN__)
@@ -74,7 +74,7 @@ void XUA_Buffer_Ep(
 #if (NUM_USB_CHAN_IN > 0) || defined(__DOXYGEN__)
             chanend c_aud_in,
 #endif
-#if ((NUM_USB_CHAN_OUT > 0) && ((NUM_USB_CHAN == 0) || defined(UAC_FORCE_FEEDBACK_EP))) || defined(__DOXYGEN__)
+#if ((NUM_USB_CHAN_OUT > 0) && ((NUM_USB_CHAN_IN == 0) || defined(UAC_FORCE_FEEDBACK_EP))) || defined(__DOXYGEN__)
             chanend c_aud_fb,
 #endif
 #ifdef MIDI

--- a/lib_xua/api/xua_conf_default.h
+++ b/lib_xua/api/xua_conf_default.h
@@ -1333,7 +1333,7 @@
 enum USBEndpointNumber_In
 {
     ENDPOINT_NUMBER_IN_CONTROL,     /* Endpoint 0 */
-#if (NUM_USB_CHAN_IN == 0) || defined (UAC_FORCE_FEEDBACK_EP)
+#if (NUM_USB_CHAN_OUT > 0) && ((NUM_USB_CHAN == 0) || defined(UAC_FORCE_FEEDBACK_EP))
     ENDPOINT_NUMBER_IN_FEEDBACK,
 #endif
 #if (NUM_USB_CHAN_IN != 0)
@@ -1363,7 +1363,9 @@ enum USBEndpointNumber_In
 enum USBEndpointNumber_Out
 {
     ENDPOINT_NUMBER_OUT_CONTROL,    /* Endpoint 0 */
+#if (NUM_USB_CHAN_OUT > 0)
     ENDPOINT_NUMBER_OUT_AUDIO,
+#endif
 #ifdef MIDI
     ENDPOINT_NUMBER_OUT_MIDI,
 #endif

--- a/lib_xua/src/core/buffer/ep/ep_buffer.xc
+++ b/lib_xua/src/core/buffer/ep/ep_buffer.xc
@@ -81,11 +81,13 @@ unsigned int fb_clocks[4];
 #define FB_TOLERANCE 0x100
 
 void XUA_Buffer(
+#if (NUM_USB_CHAN_OUT > 0)
     register chanend c_aud_out,
+#endif
 #if (NUM_USB_CHAN_IN > 0)
     register chanend c_aud_in,
 #endif
-#if (NUM_USB_CHAN_IN == 0) || defined (UAC_FORCE_FEEDBACK_EP)
+#if (NUM_USB_CHAN_OUT > 0) && ((NUM_USB_CHAN == 0) || defined(UAC_FORCE_FEEDBACK_EP))
     chanend c_aud_fb,
 #endif
 #ifdef MIDI
@@ -121,11 +123,14 @@ void XUA_Buffer(
 
     par
     {
-        XUA_Buffer_Ep(c_aud_out,          /* USB Audio Out*/
+        XUA_Buffer_Ep(
+#if (NUM_USB_CHAN_OUT > 0)
+                c_aud_out,                /* USB Audio Out*/
+#endif
 #if (NUM_USB_CHAN_IN > 0)
                 c_aud_in,                 /* USB Audio In */
 #endif
-#if (NUM_USB_CHAN_IN == 0) || defined(UAC_FORCE_FEEDBACK_EP)
+#if (NUM_USB_CHAN_OUT > 0) && ((NUM_USB_CHAN == 0) || defined(UAC_FORCE_FEEDBACK_EP))
                 c_aud_fb,                 /* Audio FB */
 #endif
 #ifdef MIDI
@@ -175,11 +180,14 @@ unsafe{volatile unsigned * unsafe masterClockFreq_ptr;}
  * @param   c_aud_fb      chanend for feeback to xud
  * @return  void
  */
-void XUA_Buffer_Ep(register chanend c_aud_out,
+void XUA_Buffer_Ep(
+#if (NUM_USB_CHAN_OUT > 0)
+    register chanend c_aud_out,
+#endif
 #if (NUM_USB_CHAN_IN > 0)
     register chanend c_aud_in,
 #endif
-#if (NUM_USB_CHAN_IN == 0) || defined (UAC_FORCE_FEEDBACK_EP)
+#if (NUM_USB_CHAN_OUT > 0) && ((NUM_USB_CHAN == 0) || defined(UAC_FORCE_FEEDBACK_EP))
     chanend c_aud_fb,
 #endif
 #ifdef MIDI
@@ -210,13 +218,15 @@ void XUA_Buffer_Ep(register chanend c_aud_out,
 #endif
     )
 {
+#if (NUM_USB_CHAN_OUT > 0)
     XUD_ep ep_aud_out = XUD_InitEp(c_aud_out);
+#endif
 
 #if (NUM_USB_CHAN_IN > 0)
     XUD_ep ep_aud_in = XUD_InitEp(c_aud_in);
 #endif
 
-#if (NUM_USB_CHAN_IN == 0) || defined (UAC_FORCE_FEEDBACK_EP)
+#if (NUM_USB_CHAN_OUT > 0) && ((NUM_USB_CHAN == 0) || defined(UAC_FORCE_FEEDBACK_EP))
     XUD_ep ep_aud_fb = XUD_InitEp(c_aud_fb);
 #endif
 
@@ -313,7 +323,9 @@ void XUA_Buffer_Ep(register chanend c_aud_out,
 #endif
 
     /* Store EP's to globals so that decouple() can access them */
+#if (NUM_USB_CHAN_OUT > 0)
     asm("stw %0, dp[aud_from_host_usb_ep]"::"r"(ep_aud_out));
+#endif
 #if (NUM_USB_CHAN_IN > 0)
     asm("stw %0, dp[aud_to_host_usb_ep]"::"r"(ep_aud_in));
 #endif
@@ -358,7 +370,7 @@ void XUA_Buffer_Ep(register chanend c_aud_out,
 #endif
 
 #if (AUDIO_CLASS == 1)
-#if (NUM_USB_CHAN_IN == 0) || defined (UAC_FORCE_FEEDBACK_EP)
+#if (NUM_USB_CHAN_OUT > 0) && ((NUM_USB_CHAN == 0) || defined(UAC_FORCE_FEEDBACK_EP))
     /* In UAC1 we dont use a stream start event (and we are always FS) so mark FB EP ready now */
     XUD_SetReady_In(ep_aud_fb, (fb_clocks, unsigned char[]), 3);
 #endif
@@ -518,7 +530,7 @@ void XUA_Buffer_Ep(register chanend c_aud_out,
                         SET_SHARED_GLOBAL(g_formatChange_DataFormat, formatChange_DataFormat);
                         SET_SHARED_GLOBAL(g_formatChange_SampRes, formatChange_SampRes);
 
-#if (NUM_USB_CHAN_IN == 0) || defined(UAC_FORCE_FEEDBACK_EP)
+#if (NUM_USB_CHAN_OUT > 0) && ((NUM_USB_CHAN == 0) || defined(UAC_FORCE_FEEDBACK_EP))
                         /* Host is starting up the output stream. Setup (or potentially resize) feedback packet based on bus-speed
                          * This is only really important on inital start up (when bus-speed
                            was unknown) and when changing bus-speeds */

--- a/lib_xua/src/core/buffer/ep/ep_buffer.xc
+++ b/lib_xua/src/core/buffer/ep/ep_buffer.xc
@@ -87,7 +87,7 @@ void XUA_Buffer(
 #if (NUM_USB_CHAN_IN > 0)
     register chanend c_aud_in,
 #endif
-#if (NUM_USB_CHAN_OUT > 0) && ((NUM_USB_CHAN == 0) || defined(UAC_FORCE_FEEDBACK_EP))
+#if (NUM_USB_CHAN_OUT > 0) && ((NUM_USB_CHAN_IN == 0) || defined(UAC_FORCE_FEEDBACK_EP))
     chanend c_aud_fb,
 #endif
 #ifdef MIDI
@@ -130,7 +130,7 @@ void XUA_Buffer(
 #if (NUM_USB_CHAN_IN > 0)
                 c_aud_in,                 /* USB Audio In */
 #endif
-#if (NUM_USB_CHAN_OUT > 0) && ((NUM_USB_CHAN == 0) || defined(UAC_FORCE_FEEDBACK_EP))
+#if (NUM_USB_CHAN_OUT > 0) && ((NUM_USB_CHAN_IN == 0) || defined(UAC_FORCE_FEEDBACK_EP))
                 c_aud_fb,                 /* Audio FB */
 #endif
 #ifdef MIDI
@@ -187,7 +187,7 @@ void XUA_Buffer_Ep(
 #if (NUM_USB_CHAN_IN > 0)
     register chanend c_aud_in,
 #endif
-#if (NUM_USB_CHAN_OUT > 0) && ((NUM_USB_CHAN == 0) || defined(UAC_FORCE_FEEDBACK_EP))
+#if (NUM_USB_CHAN_OUT > 0) && ((NUM_USB_CHAN_IN == 0) || defined(UAC_FORCE_FEEDBACK_EP))
     chanend c_aud_fb,
 #endif
 #ifdef MIDI
@@ -226,7 +226,7 @@ void XUA_Buffer_Ep(
     XUD_ep ep_aud_in = XUD_InitEp(c_aud_in);
 #endif
 
-#if (NUM_USB_CHAN_OUT > 0) && ((NUM_USB_CHAN == 0) || defined(UAC_FORCE_FEEDBACK_EP))
+#if (NUM_USB_CHAN_OUT > 0) && ((NUM_USB_CHAN_IN == 0) || defined(UAC_FORCE_FEEDBACK_EP))
     XUD_ep ep_aud_fb = XUD_InitEp(c_aud_fb);
 #endif
 
@@ -530,7 +530,7 @@ void XUA_Buffer_Ep(
                         SET_SHARED_GLOBAL(g_formatChange_DataFormat, formatChange_DataFormat);
                         SET_SHARED_GLOBAL(g_formatChange_SampRes, formatChange_SampRes);
 
-#if (NUM_USB_CHAN_OUT > 0) && ((NUM_USB_CHAN == 0) || defined(UAC_FORCE_FEEDBACK_EP))
+#if (NUM_USB_CHAN_OUT > 0) && ((NUM_USB_CHAN_IN == 0) || defined(UAC_FORCE_FEEDBACK_EP))
                         /* Host is starting up the output stream. Setup (or potentially resize) feedback packet based on bus-speed
                          * This is only really important on inital start up (when bus-speed
                            was unknown) and when changing bus-speeds */

--- a/lib_xua/src/core/main.xc
+++ b/lib_xua/src/core/main.xc
@@ -231,7 +231,7 @@ XUD_EpType epTypeTableIn[ENDPOINT_COUNT_IN] = { XUD_EPTYPE_CTL | XUD_STATUS_ENAB
 #if (NUM_USB_CHAN_IN > 0)
                                             XUD_EPTYPE_ISO,
 #endif
-#if (NUM_USB_CHAN_OUT > 0) && ((NUM_USB_CHAN == 0) || defined(UAC_FORCE_FEEDBACK_EP))
+#if (NUM_USB_CHAN_OUT > 0) && ((NUM_USB_CHAN_IN == 0) || defined(UAC_FORCE_FEEDBACK_EP))
                                             XUD_EPTYPE_ISO,    /* Async feedback endpoint */
 #endif
 #if (XUA_SPDIF_RX_EN || XUA_ADAT_RX_EN)
@@ -580,7 +580,7 @@ int main()
 #if (NUM_USB_CHAN_IN > 0)
                            c_xud_in[ENDPOINT_NUMBER_IN_AUDIO],         /* Audio In */
 #endif
-#if (NUM_USB_CHAN_OUT > 0) && ((NUM_USB_CHAN == 0) || defined(UAC_FORCE_FEEDBACK_EP))
+#if (NUM_USB_CHAN_OUT > 0) && ((NUM_USB_CHAN_IN == 0) || defined(UAC_FORCE_FEEDBACK_EP))
                            c_xud_in[ENDPOINT_NUMBER_IN_FEEDBACK],      /* Audio FB */
 #endif
 #ifdef MIDI


### PR DESCRIPTION
The original issue I attempted to fix was the endpoint type table when NUM_USB_CHAN_IN == NUM_USB_CHAN_OUT == 0. 

The issue was the that the EP type for the HID EP was marked as an ISO endpoint, thus making the PID toggling invalid.

However, fixing this table had knock on effects on the offsets of channels used from arrays etc, so the changes became wider reaching. 

Ultimately this means that the I2S build with audio class 2 descriptors now functions. 