### PR TITLE
Fix up NUM_USB_CHAN_IN/OUT macros

### DIFF
--- a/lib_xua/api/xua_conf_default.h
+++ b/lib_xua/api/xua_conf_default.h
@@ -1333,7 +1333,7 @@
 enum USBEndpointNumber_In
 {
     ENDPOINT_NUMBER_IN_CONTROL,     /* Endpoint 0 */
-#if (NUM_USB_CHAN_OUT > 0) && ((NUM_USB_CHAN == 0) || defined(UAC_FORCE_FEEDBACK_EP))
+#if (NUM_USB_CHAN_OUT > 0) && ((NUM_USB_CHAN_IN == 0) || defined(UAC_FORCE_FEEDBACK_EP))
     ENDPOINT_NUMBER_IN_FEEDBACK,
 #endif
 #if (NUM_USB_CHAN_IN != 0)

--- a/lib_xua/src/core/buffer/ep/ep_buffer.xc
+++ b/lib_xua/src/core/buffer/ep/ep_buffer.xc
@@ -370,7 +370,7 @@ void XUA_Buffer_Ep(
 #endif
 
 #if (AUDIO_CLASS == 1)
-#if (NUM_USB_CHAN_OUT > 0) && ((NUM_USB_CHAN == 0) || defined(UAC_FORCE_FEEDBACK_EP))
+#if (NUM_USB_CHAN_OUT > 0) && ((NUM_USB_CHAN_IN == 0) || defined(UAC_FORCE_FEEDBACK_EP))
     /* In UAC1 we dont use a stream start event (and we are always FS) so mark FB EP ready now */
     XUD_SetReady_In(ep_aud_fb, (fb_clocks, unsigned char[]), 3);
 #endif

--- a/lib_xua/src/core/endpoint0/xua_ep0_descriptors.h
+++ b/lib_xua/src/core/endpoint0/xua_ep0_descriptors.h
@@ -204,7 +204,7 @@ typedef struct
 #endif
 
 #if (NUM_USB_CHAN_OUT > 32)
-#error NUM_USB_CHAN > 32
+#error NUM_USB_CHAN_OUT > 32
 #endif
 
 #if (NUM_USB_CHAN_IN > 0)
@@ -305,7 +305,7 @@ typedef struct
 #endif
 
 #if (NUM_USB_CHAN_IN > 32)
-#error NUM_USB_CHAN > 32
+#error NUM_USB_CHAN_IN > 32
 #endif
 
 #if (MIXER) && (MAX_MIX_COUNT > 0)


### PR DESCRIPTION
I noticed a couple of lines in #405 where the NUM_USB_CHAN macro was missing the IN/OUT direction. Also there were some error messages which I've made explicit as IN/OUT.