### PR TITLE
Audio control interface no longer presented in descriptors if NUM_USB_CHAN_OUT == NUM_USB_CHAN_IN == 0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,8 @@ UNRELEASED
 
   * CHANGED:    Using lsats instruction for saturation in the mixer
   * CHANGED:    Simplified the mixer threads communication scheme
+  * CHANGED:    Audio Class Control Interface no longer presented in descriptors if NUM_USB_CHAN_IN
+    and NUM_USB_CHAN_OUT are both zero
 
   * Changes to dependencies:
 

--- a/lib_xua/src/core/endpoint0/descriptor_defs.h
+++ b/lib_xua/src/core/endpoint0/descriptor_defs.h
@@ -1,8 +1,8 @@
-// Copyright 2015-2023 XMOS LIMITED.
+// Copyright 2015-2024 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 
-#ifndef __DESCRIPTOR_DEFS_H__
-#define __DESCRIPTOR_DEFS_H__
+#ifndef _DESCRIPTOR_DEFS_H_
+#define _DESCRIPTOR_DEFS_H_
 
 /*
     Include xua.h to pick up the #defines of NUM_USB_CHAN_IN and NUM_USB_CHAN_OUT.

--- a/lib_xua/src/core/endpoint0/descriptor_defs.h
+++ b/lib_xua/src/core/endpoint0/descriptor_defs.h
@@ -10,11 +10,11 @@
 #include "xua.h"
 
 #if (NUM_USB_CHAN_IN > 0) && (NUM_USB_CHAN_OUT > 0)
-#define AUDIO_INTERFACE_COUNT 3
+#define AUDIO_INTERFACE_COUNT (3)
 #elif (NUM_USB_CHAN_IN > 0) || (NUM_USB_CHAN_OUT > 0)
-#define AUDIO_INTERFACE_COUNT 2
+#define AUDIO_INTERFACE_COUNT (2)
 #else
-#define AUDIO_INTERFACE_COUNT 1
+#define AUDIO_INTERFACE_COUNT (0)
 #endif
 
 /* Endpoint address defines */
@@ -38,7 +38,9 @@
 /* Interface numbers enum */
 enum USBInterfaceNumber
 {
+#if (NUM_USB_CHAN_IN > 0) || (NUM_USB_CHAN_OUT > 0)
     INTERFACE_NUMBER_AUDIO_CONTROL = 0,
+#endif
 #if (NUM_USB_CHAN_OUT > 0)
     INTERFACE_NUMBER_AUDIO_OUTPUT,
 #endif
@@ -68,11 +70,11 @@ enum USBInterfaceNumber
 };
 
 #ifndef ENDPOINT_INT_INTERVAL_IN_HID
-#define ENDPOINT_INT_INTERVAL_IN_HID 0x08
+#define ENDPOINT_INT_INTERVAL_IN_HID (0x08)
 #endif
 
 #ifndef ENDPOINT_INT_INTERVAL_OUT_HID
-#define ENDPOINT_INT_INTERVAL_OUT_HID 0x08
+#define ENDPOINT_INT_INTERVAL_OUT_HID (0x08)
 #endif
 
 #endif

--- a/lib_xua/src/core/endpoint0/xua_endpoint0.c
+++ b/lib_xua/src/core/endpoint0/xua_endpoint0.c
@@ -820,7 +820,9 @@ void XUA_Endpoint0_loop(XUD_Result_t result, USB_SetupPacket_t sp, chanend c_ep0
             case USB_BMREQ_H2D_CLASS_EP:
             case USB_BMREQ_D2H_CLASS_EP:
                 {
+#if (NUM_USB_CHAN_OUT > 0) || (NUM_USB_CHAN_IN > 0)
                     unsigned epNum = sp.wIndex & 0xff;
+#endif
 
 // Ensure we only check for AUDIO EPs if enabled
 #if (NUM_USB_CHAN_IN != 0 && NUM_USB_CHAN_OUT == 0)
@@ -855,7 +857,7 @@ void XUA_Endpoint0_loop(XUD_Result_t result, USB_SetupPacket_t sp, chanend c_ep0
                     unsigned DFU_IF = INTERFACE_NUMBER_DFU;
 
                     /* DFU interface number changes based on which mode we are currently running in */
-                    if (DFU_mode_active)
+                    if(DFU_mode_active)
                     {
                         DFU_IF = 0;
                     }
@@ -866,8 +868,9 @@ void XUA_Endpoint0_loop(XUD_Result_t result, USB_SetupPacket_t sp, chanend c_ep0
 
                         /* If running in application mode stop audio */
                         /* Don't interupt audio for save and restore cmds */
-                        if ((DFU_IF == INTERFACE_NUMBER_DFU) && (sp.bRequest != XMOS_DFU_SAVESTATE) &&
-                            (sp.bRequest != XMOS_DFU_RESTORESTATE))
+                        if (!DFU_mode_active
+                                && (sp.bRequest != XMOS_DFU_SAVESTATE)
+                                && (sp.bRequest != XMOS_DFU_RESTORESTATE))
                         {
                             assert((c_audioControl != null) && msg("DFU not supported when c_audioControl is null"));
                             // Stop audio

--- a/lib_xua/src/core/endpoint0/xua_ep0_descriptors.h
+++ b/lib_xua/src/core/endpoint0/xua_ep0_descriptors.h
@@ -353,7 +353,6 @@ StringDescTable_t g_strTable =
     .usbOutputTermStr_Audio2     = XUA_PRODUCT_EMPTY_STRING,
 #endif
 #if (AUDIO_CLASS_FALLBACK) || (AUDIO_CLASS == 1)
-
     .productStr_Audio1           = XUA_PRODUCT_EMPTY_STRING,
     .outputInterfaceStr_Audio1   = XUA_PRODUCT_EMPTY_STRING,
     .inputInterfaceStr_Audio1    = XUA_PRODUCT_EMPTY_STRING,
@@ -450,22 +449,6 @@ USB_Descriptor_Device_t devDesc_Audio1 =
 #endif
 
 #if (AUDIO_CLASS == 2)
-/* Device Descriptor for Audio Class 2.0 (Assumes High-Speed )
- *
- * The use of two configurations dates back to Windows XP (could be SP2). This
- * lacked some standards support and incorrectly parsed the full audio class 2.0
- * descriptor with its IADs (Interface Association Descriptors). The observed
- * behaviour included loading the built-in audio class 1.0 driver on some
- * interfaces (possibly the wrong ones, too), and hanging.
- *
- * Presenting a blank configuration first prevented loading the composite driver
- * and issues arising from it, while still allowing to load a vendor driver on
- * the actual configuration.
- *
- * Recent Windows subsystem can parse our class 2.0 descriptor correctly
- * (certainly Windows 7 and onwards). It may be possible to remove this
- * workaround.
- */
 USB_Descriptor_Device_t devDesc_Audio2 =
 {
     .bLength                        = sizeof(USB_Descriptor_Device_t),
@@ -702,11 +685,13 @@ typedef struct
     /* Configuration header */
     USB_Descriptor_Configuration_Header_t       Config;
 
+#if (NUM_USB_CHAN_OUT > 0) || (NUM_USB_CHAN_IN > 0)
     /* Audio Control */
     USB_Descriptor_Interface_Association_t      Audio_InterfaceAssociation;
     USB_Descriptor_Interface_t                  Audio_StdControlInterface;       /* Standard Audio Control Interface Header Descriptor */
 
     USB_CfgDesc_Audio2_CS_Control_Int           Audio_CS_Control_Int;
+#endif //#if (NUM_USB_CHAN_OUT > 0) || (NUM_USB_CHAN_IN > 0)
 #if (NUM_USB_CHAN_OUT > 0)
     /* Audio streaming: Output stream */
     USB_Descriptor_Interface_t                  Audio_Out_StreamInterface_Alt0;  /* Zero bandwith alternative */
@@ -822,6 +807,7 @@ USB_Config_Descriptor_Audio2_t cfgDesc_Audio2=
         .bMaxPower                  = _XUA_BMAX_POWER,
     },
 
+#if (NUM_USB_CHAN_OUT > 0) || (NUM_USB_CHAN_IN > 0)
     .Audio_InterfaceAssociation =
     {
         .bLength                    = sizeof(USB_Descriptor_Interface_Association_t),
@@ -935,7 +921,6 @@ USB_Config_Descriptor_Audio2_t cfgDesc_Audio2=
             .iClockSource              = offsetof(StringDescTable_t, adatClockSourceStr)/sizeof(char *),
         },
 #endif
-
 
         /* Clock Selector Descriptor (4.7.2.2) */
         .Audio_ClockSelector =
@@ -1415,6 +1400,7 @@ USB_Config_Descriptor_Audio2_t cfgDesc_Audio2=
         },
 #endif
     }, /* End of .Audio_CS_Control_Int */
+#endif //#if (NUM_USB_CHAN_OUT > 0) || (NUM_USB_CHAN_IN > 0)
 
 #if (NUM_USB_CHAN_OUT > 0)
     /* Zero bandwith alternative 0 */
@@ -2377,7 +2363,7 @@ const unsigned num_freqs_a1 = MAX(3, (0
 #define STREAMING_INTERFACES        (INPUT_INTERFACES_A1 + OUTPUT_INTERFACES_A1)
 
 /* Number of interfaces for Audio  1.0 (+1 for control ) */
-/* Note, this is different that INTERFACE_COUNT since we dont support items such as MIDI, iAP etc in UAC1 mode */
+/* Note, this is different than INTERFACE_COUNT since we dont support items such as MIDI, iAP etc in UAC1 mode */
 #define NUM_INTERFACES_A1           (1 + INPUT_INTERFACES_A1 + OUTPUT_INTERFACES_A1 + NUM_CONTROL_USB_INTERFACES + DFU_INTERFACES_A1 + HID_INTERFACES_A1)
 
 #if ((NUM_USB_CHAN_IN == 0) || defined(UAC_FORCE_FEEDBACK_EP)) && (XUA_SYNCMODE == XUA_SYNCMODE_ASYNC)


### PR DESCRIPTION
When the device is configured as having no USB Audio Channels (i.e. device is just hid/midi/dfu) then don't expose any UA descriptors. 

Note, had to tweak DFU interface checking code slightly as there is now the potential that the mission mode and dfu mode DFU-interface numbers are now the same (i.e. 0)