### PR TITLE
Feat/remove ua cores

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,8 @@ UNRELEASED
 
   * CHANGED:    Using lsats instruction for saturation in the mixer
   * CHANGED:    Simplified the mixer threads communication scheme
+  * CHANGED:    Audio Class Control Interface no longer presented in descriptors if NUM_USB_CHAN_IN
+    and NUM_USB_CHAN_OUT are both zero
 
   * Changes to dependencies:
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,9 @@ UNRELEASED
   * CHANGED:    Simplified the mixer threads communication scheme
   * CHANGED:    Audio Class Control Interface no longer presented in descriptors if NUM_USB_CHAN_IN
     and NUM_USB_CHAN_OUT are both zero
+  * CHANGED:    Buffering sub-system no longer spawns if NUM_USB_CHAN_IN and NUM_USB_CHAN_OUT are
+    both zero
+  * CHANGED:    Communication of commands between tasks now uniformly uses control tokens.
 
   * Changes to dependencies:
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,13 +4,14 @@ lib_xua change log
 UNRELEASED
 ----------
 
-  * CHANGED:    Using lsats instruction for saturation in the mixer
-  * CHANGED:    Simplified the mixer threads communication scheme
+  * CHANGED:    lsats instruction used for saturation in the mixer
+  * CHANGED:    Mixer task communication scheme simplified, aiding code reuse & performance
   * CHANGED:    Audio Class Control Interface no longer presented in descriptors if NUM_USB_CHAN_IN
     and NUM_USB_CHAN_OUT are both zero
   * CHANGED:    Buffering sub-system no longer spawns if NUM_USB_CHAN_IN and NUM_USB_CHAN_OUT are
     both zero
   * CHANGED:    Communication of commands between tasks now uniformly uses control tokens.
+    Potentially making mix & match of components more tractable in the future
 
   * Changes to dependencies:
 

--- a/lib_xua/api/xua_endpoint0.h
+++ b/lib_xua/api/xua_endpoint0.h
@@ -13,7 +13,7 @@
  *
  *  \param c_ep0_out    Chanend connected to the XUD_Manager() out endpoint array
  *  \param c_ep0_in     Chanend connected to the XUD_Manager() in endpoint array
- *  \param c_audioCtrl  Chanend connected to the decouple thread for control
+ *  \param c_aud_ctl    Chanend connected to the decouple thread for control
  *                      audio (sample rate changes etc.). Note when nulled, the
  *                      audio device only supports single sample rate/format and
  *                      DFU is not supported either since this channel is used
@@ -28,7 +28,7 @@
  *                                  endpoint manager if present
  */
 void XUA_Endpoint0(chanend c_ep0_out,
-                    chanend c_ep0_in, chanend ?c_audioCtrl,
+                    chanend c_ep0_in, chanend ?c_aud_ctl,
                     chanend ?c_mix_ctl, chanend ?c_clk_ctl,
                     chanend ?c_EANativeTransport_ctrl,
                     client interface i_dfu ?dfuInterface

--- a/lib_xua/src/core/audiohub/xua_audiohub.xc
+++ b/lib_xua/src/core/audiohub/xua_audiohub.xc
@@ -586,6 +586,7 @@ static void dummy_deliver(chanend ?c_out, unsigned &command)
 
     while (1)
     {
+        /* Note, a select is used such that this task is combinable */
         select
         {
             /* Check for sample freq change or new samples from mixer*/

--- a/lib_xua/src/core/audiohub/xua_audiohub.xc
+++ b/lib_xua/src/core/audiohub/xua_audiohub.xc
@@ -617,6 +617,7 @@ static void dummy_deliver(chanend ?c_out, unsigned &command)
 #endif
                 }
 
+                /* Request more data */
                 outuint(c_out, 0);
             break;
         }
@@ -915,6 +916,7 @@ void XUA_AudioHub(chanend ?c_aud, clock ?clk_audio_mclk, clock ?clk_audio_bclk,
                 /* Currently no more audio will happen after this point */
                 if ((curSamFreq / AUD_TO_USB_RATIO) == AUDIO_STOP_FOR_DFU)
                 {
+                    /* Handshake back */
                     outct(c_aud, XS1_CT_END);
 
                     outuint(c_aud, 0);

--- a/lib_xua/src/core/audiohub/xua_audiohub_st.h
+++ b/lib_xua/src/core/audiohub/xua_audiohub_st.h
@@ -47,6 +47,7 @@ static inline unsigned DoSampleTransfer(chanend ?c_out, const int readBuffNo, co
 #else
             inuint(c_out);
 #endif
+            /* Run user code */
             UserBufferManagement(samplesOut, samplesIn[readBuffNo]);
 
 #if NUM_USB_CHAN_IN > 0
@@ -59,7 +60,28 @@ static inline unsigned DoSampleTransfer(chanend ?c_out, const int readBuffNo, co
         }
     }
     else
+    {
+        if(XUA_USB_EN)
+        {
+            /* In this case USB is still enabled, even though we have no audio channels to/from
+             * host. Check for cmd - only expecting STOP_AUDIO_FOR_DFU. The select above cannot be
+             * used since EP0 is not expecting to be polled */
+            unsigned command = 0;
+            select
+            {
+                case inuint_byref(c_out, command):
+                    break;
+
+                default:
+                    break;
+            }
+
+            if(command)
+                return command;
+        }
+        /* Run user code */
         UserBufferManagement(samplesOut, samplesIn[readBuffNo]);
+    }
 
     return 0;
 }

--- a/lib_xua/src/core/audiohub/xua_audiohub_st.h
+++ b/lib_xua/src/core/audiohub/xua_audiohub_st.h
@@ -66,10 +66,10 @@ static inline unsigned DoSampleTransfer(chanend ?c_out, const int readBuffNo, co
             /* In this case USB is still enabled, even though we have no audio channels to/from
              * host. Check for cmd - only expecting STOP_AUDIO_FOR_DFU. The select above cannot be
              * used since EP0 is not expecting to be polled */
-            unsigned command = 0;
+            unsigned char command = 0;
             select
             {
-                case inuint_byref(c_out, command):
+                case inct_byref(c_out, command):
                     break;
 
                 default:
@@ -77,7 +77,7 @@ static inline unsigned DoSampleTransfer(chanend ?c_out, const int readBuffNo, co
             }
 
             if(command)
-                return command;
+                return (unsigned) command;
         }
         /* Run user code */
         UserBufferManagement(samplesOut, samplesIn[readBuffNo]);

--- a/lib_xua/src/core/audiohub/xua_audiohub_st.h
+++ b/lib_xua/src/core/audiohub/xua_audiohub_st.h
@@ -4,7 +4,7 @@
 #pragma unsafe arrays
 static inline unsigned DoSampleTransfer(chanend ?c_out, const int readBuffNo, const unsigned underflowWord)
 {
-    if(XUA_USB_EN)
+    if(XUA_USB_EN && ((NUM_USB_CHAN_OUT > 0) || (NUM_USB_CHAN_IN > 0)))
     {
         outuint(c_out, underflowWord);
 

--- a/lib_xua/src/core/buffer/ep/ep_buffer.xc
+++ b/lib_xua/src/core/buffer/ep/ep_buffer.xc
@@ -253,6 +253,7 @@ void XUA_Buffer_Ep(
     XUD_ep ep_hid = XUD_InitEp(c_hid);
 #endif
     unsigned u_tmp;
+    unsigned char cmd;
     unsigned sampleFreq = DEFAULT_FREQ;
     unsigned masterClockFreq = DEFAULT_MCLK_FREQ;
 
@@ -445,10 +446,8 @@ void XUA_Buffer_Ep(
             }
 #endif
             /* Sample Freq or stream format update (e.g. channel count) from Endpoint 0 core */
-            case inuint_byref(c_aud_ctl, u_tmp):
+            case inct_byref(c_aud_ctl, cmd):
             {
-                unsigned cmd = u_tmp;
-
                 if(cmd == SET_SAMPLE_FREQ)
                 {
                     unsigned receivedSampleFreq = inuint(c_aud_ctl);

--- a/lib_xua/src/core/endpoint0/descriptor_defs.h
+++ b/lib_xua/src/core/endpoint0/descriptor_defs.h
@@ -1,8 +1,8 @@
-// Copyright 2015-2023 XMOS LIMITED.
+// Copyright 2015-2024 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 
-#ifndef __DESCRIPTOR_DEFS_H__
-#define __DESCRIPTOR_DEFS_H__
+#ifndef _DESCRIPTOR_DEFS_H_
+#define _DESCRIPTOR_DEFS_H_
 
 /*
     Include xua.h to pick up the #defines of NUM_USB_CHAN_IN and NUM_USB_CHAN_OUT.

--- a/lib_xua/src/core/endpoint0/descriptor_defs.h
+++ b/lib_xua/src/core/endpoint0/descriptor_defs.h
@@ -10,11 +10,11 @@
 #include "xua.h"
 
 #if (NUM_USB_CHAN_IN > 0) && (NUM_USB_CHAN_OUT > 0)
-#define AUDIO_INTERFACE_COUNT 3
+#define AUDIO_INTERFACE_COUNT (3)
 #elif (NUM_USB_CHAN_IN > 0) || (NUM_USB_CHAN_OUT > 0)
-#define AUDIO_INTERFACE_COUNT 2
+#define AUDIO_INTERFACE_COUNT (2)
 #else
-#define AUDIO_INTERFACE_COUNT 1
+#define AUDIO_INTERFACE_COUNT (0)
 #endif
 
 /* Endpoint address defines */
@@ -38,7 +38,9 @@
 /* Interface numbers enum */
 enum USBInterfaceNumber
 {
+#if (NUM_USB_CHAN_IN > 0) || (NUM_USB_CHAN_OUT > 0)
     INTERFACE_NUMBER_AUDIO_CONTROL = 0,
+#endif
 #if (NUM_USB_CHAN_OUT > 0)
     INTERFACE_NUMBER_AUDIO_OUTPUT,
 #endif
@@ -68,11 +70,11 @@ enum USBInterfaceNumber
 };
 
 #ifndef ENDPOINT_INT_INTERVAL_IN_HID
-#define ENDPOINT_INT_INTERVAL_IN_HID 0x08
+#define ENDPOINT_INT_INTERVAL_IN_HID (0x08)
 #endif
 
 #ifndef ENDPOINT_INT_INTERVAL_OUT_HID
-#define ENDPOINT_INT_INTERVAL_OUT_HID 0x08
+#define ENDPOINT_INT_INTERVAL_OUT_HID (0x08)
 #endif
 
 #endif

--- a/lib_xua/src/core/endpoint0/vendorrequests.c
+++ b/lib_xua/src/core/endpoint0/vendorrequests.c
@@ -7,12 +7,12 @@
 #include "vendorrequests.h"
 
 int VendorAudioRequests(XUD_ep ep0_out, XUD_ep ep0_in, unsigned char bRequest, unsigned char cs, unsigned char cn,
-    unsigned short unitId, unsigned char direction, NULLABLE_RESOURCE(chanend, c_audioControl),
+    unsigned short unitId, unsigned char direction, NULLABLE_RESOURCE(chanend, c_aud_ctl),
     NULLABLE_RESOURCE(chanend, c_mix_ctl),
     NULLABLE_RESOURCE(chanend, c_clk_ctL)) __attribute__ ((weak));
 
 int VendorAudioRequests(XUD_ep ep0_out, XUD_ep ep0_in, unsigned char bRequest, unsigned char cs, unsigned char cn,
-    unsigned short unitId, unsigned char direction, NULLABLE_RESOURCE(chanend, c_audioControl),
+    unsigned short unitId, unsigned char direction, NULLABLE_RESOURCE(chanend, c_aud_ctl),
     NULLABLE_RESOURCE(chanend, c_mix_ctl),
     NULLABLE_RESOURCE(chanend, c_clk_ctL))
 {

--- a/lib_xua/src/core/endpoint0/vendorrequests.h
+++ b/lib_xua/src/core/endpoint0/vendorrequests.h
@@ -33,7 +33,7 @@
 #endif
 
 int VendorAudioRequests(XUD_ep ep0_out, XUD_ep ep0_in, unsigned char bRequest, unsigned char cs, unsigned char cn,
-    unsigned short unitId, unsigned char direction, NULLABLE_RESOURCE(chanend, c_audioControl),
+    unsigned short unitId, unsigned char direction, NULLABLE_RESOURCE(chanend, c_aud_ctl),
     NULLABLE_RESOURCE(chanend, c_mix_ctl),
     NULLABLE_RESOURCE(chanend, c_clk_ctL));
 

--- a/lib_xua/src/core/endpoint0/xua_endpoint0.c
+++ b/lib_xua/src/core/endpoint0/xua_endpoint0.c
@@ -459,7 +459,7 @@ static unsigned char hidReportDescriptorPtr[] = {
 
 
 
-void XUA_Endpoint0_init(chanend c_ep0_out, chanend c_ep0_in, NULLABLE_RESOURCE(chanend, c_audioControl),
+void XUA_Endpoint0_init(chanend c_ep0_out, chanend c_ep0_in, NULLABLE_RESOURCE(chanend, c_aud_ctl),
     chanend c_mix_ctl, chanend c_clk_ctl, chanend c_EANativeTransport_ctrl, CLIENT_INTERFACE(i_dfu, dfuInterface) VENDOR_REQUESTS_PARAMS_DEC_)
 {
     ep0_out = XUD_InitEp(c_ep0_out);
@@ -475,18 +475,18 @@ void XUA_Endpoint0_init(chanend c_ep0_out, chanend c_ep0_in, NULLABLE_RESOURCE(c
 #endif
 
 #ifdef VENDOR_AUDIO_REQS
-    VendorAudioRequestsInit(c_audioControl, c_mix_ctl, c_clk_ctl);
+    VendorAudioRequestsInit(c_aud_ctl, c_mix_ctl, c_clk_ctl);
 #endif
 
 #if (XUA_DFU_EN == 1)
     /* Check if device has started in DFU mode */
     if (DFUReportResetState(null))
     {
-        assert(((unsigned)c_audioControl != 0) && msg("DFU not supported when c_audioControl is null"));
+        assert(((unsigned)c_aud_ctl != 0) && msg("DFU not supported when c_aud_ctl is null"));
 
         /* Stop audio */
-        outuint(c_audioControl, SET_SAMPLE_FREQ);
-        outuint(c_audioControl, AUDIO_STOP_FOR_DFU);
+        outuint(c_aud_ctl, SET_SAMPLE_FREQ);
+        outuint(c_aud_ctl, AUDIO_STOP_FOR_DFU);
         /* No Handshake */
         DFU_mode_active = 1;
     }
@@ -552,7 +552,7 @@ void XUA_Endpoint0_init(chanend c_ep0_out, chanend c_ep0_in, NULLABLE_RESOURCE(c
 
 }
 
-void XUA_Endpoint0_loop(XUD_Result_t result, USB_SetupPacket_t sp, chanend c_ep0_out, chanend c_ep0_in, NULLABLE_RESOURCE(chanend, c_audioControl),
+void XUA_Endpoint0_loop(XUD_Result_t result, USB_SetupPacket_t sp, chanend c_ep0_out, chanend c_ep0_in, NULLABLE_RESOURCE(chanend, c_aud_ctl),
     chanend c_mix_ctl, chanend c_clk_ctl, chanend c_EANativeTransport_ctrl, CLIENT_INTERFACE(i_dfu, dfuInterface) VENDOR_REQUESTS_PARAMS_DEC_)
 {
  if (result == XUD_RES_OKAY)
@@ -579,28 +579,28 @@ void XUA_Endpoint0_loop(XUD_Result_t result, USB_SetupPacket_t sp, chanend c_ep0
                                 /* Only send change if we need to */
                                 if((sp.wValue > 0) && (g_curStreamAlt_Out != sp.wValue))
                                 {
-                                    assert((c_audioControl != null) && msg("Format change not supported when c_audioControl is null"));
+                                    assert((c_aud_ctl != null) && msg("Format change not supported when c_aud_ctl is null"));
                                     g_curStreamAlt_Out = sp.wValue;
 
                                     /* Send format of data onto buffering */
-                                    outuint(c_audioControl, SET_STREAM_FORMAT_OUT);
-                                    outuint(c_audioControl, g_dataFormat_Out[sp.wValue-1]);        /* Data format (PCM/DSD) */
+                                    outuint(c_aud_ctl, SET_STREAM_FORMAT_OUT);
+                                    outuint(c_aud_ctl, g_dataFormat_Out[sp.wValue-1]);        /* Data format (PCM/DSD) */
 
                                     if(g_curUsbSpeed == XUD_SPEED_HS)
                                     {
-                                        outuint(c_audioControl, g_chanCount_Out_HS[sp.wValue-1]);                 /* Channel count */
-                                        outuint(c_audioControl, g_subSlot_Out_HS[sp.wValue-1]);    /* Subslot */
-                                        outuint(c_audioControl, g_sampRes_Out_HS[sp.wValue-1]);    /* Resolution */
+                                        outuint(c_aud_ctl, g_chanCount_Out_HS[sp.wValue-1]);                 /* Channel count */
+                                        outuint(c_aud_ctl, g_subSlot_Out_HS[sp.wValue-1]);    /* Subslot */
+                                        outuint(c_aud_ctl, g_sampRes_Out_HS[sp.wValue-1]);    /* Resolution */
                                     }
                                     else
                                     {
-                                        outuint(c_audioControl, NUM_USB_CHAN_OUT_FS);              /* Channel count */
-                                        outuint(c_audioControl, g_subSlot_Out_FS[sp.wValue-1]);    /* Subslot */
-                                        outuint(c_audioControl, g_sampRes_Out_FS[sp.wValue-1]);    /* Resolution */
+                                        outuint(c_aud_ctl, NUM_USB_CHAN_OUT_FS);              /* Channel count */
+                                        outuint(c_aud_ctl, g_subSlot_Out_FS[sp.wValue-1]);    /* Subslot */
+                                        outuint(c_aud_ctl, g_sampRes_Out_FS[sp.wValue-1]);    /* Resolution */
                                     }
 
                                     /* Handshake */
-                                    chkct(c_audioControl, XS1_CT_END);
+                                    chkct(c_aud_ctl, XS1_CT_END);
                                 }
                             }
                             break;
@@ -615,28 +615,28 @@ void XUA_Endpoint0_loop(XUD_Result_t result, USB_SetupPacket_t sp, chanend c_ep0
                                 /* Only send change if we need to */
                                 if((sp.wValue > 0) && (g_curStreamAlt_In != sp.wValue))
                                 {
-                                    assert((c_audioControl != null) && msg("Format change not supported when c_audioControl is null"));
+                                    assert((c_aud_ctl != null) && msg("Format change not supported when c_aud_ctl is null"));
                                     g_curStreamAlt_In = sp.wValue;
 
                                     /* Send format of data onto buffering */
-                                    outuint(c_audioControl, SET_STREAM_FORMAT_IN);
-                                    outuint(c_audioControl, g_dataFormat_In[sp.wValue-1]);        /* Data format (PCM/DSD) */
+                                    outuint(c_aud_ctl, SET_STREAM_FORMAT_IN);
+                                    outuint(c_aud_ctl, g_dataFormat_In[sp.wValue-1]);        /* Data format (PCM/DSD) */
 
                                     if(g_curUsbSpeed == XUD_SPEED_HS)
                                     {
-                                        outuint(c_audioControl, g_chanCount_In_HS[sp.wValue-1]);  /* Channel count */
-                                        outuint(c_audioControl, g_subSlot_In_HS[sp.wValue-1]);    /* Subslot */
-                                        outuint(c_audioControl, g_sampRes_In_HS[sp.wValue-1]);    /* Resolution */
+                                        outuint(c_aud_ctl, g_chanCount_In_HS[sp.wValue-1]);  /* Channel count */
+                                        outuint(c_aud_ctl, g_subSlot_In_HS[sp.wValue-1]);    /* Subslot */
+                                        outuint(c_aud_ctl, g_sampRes_In_HS[sp.wValue-1]);    /* Resolution */
                                     }
                                     else
                                     {
-                                        outuint(c_audioControl, NUM_USB_CHAN_IN_FS);               /* Channel count */
-                                        outuint(c_audioControl, g_subSlot_In_FS[sp.wValue-1]);     /* Subslot */
-                                        outuint(c_audioControl, g_sampRes_In_FS[sp.wValue-1]);     /* Resolution */
+                                        outuint(c_aud_ctl, NUM_USB_CHAN_IN_FS);               /* Channel count */
+                                        outuint(c_aud_ctl, g_subSlot_In_FS[sp.wValue-1]);     /* Subslot */
+                                        outuint(c_aud_ctl, g_sampRes_In_FS[sp.wValue-1]);     /* Resolution */
                                     }
 
                                     /* Wait for handshake */
-                                    chkct(c_audioControl, XS1_CT_END);
+                                    chkct(c_aud_ctl, XS1_CT_END);
                                 }
                             }
                             break;
@@ -836,10 +836,10 @@ void XUA_Endpoint0_loop(XUD_Result_t result, USB_SetupPacket_t sp, chanend c_ep0
 #if (AUDIO_CLASS == 2) && (AUDIO_CLASS_FALLBACK)
                         if(g_curUsbSpeed == XUD_SPEED_FS)
                         {
-                            result = AudioEndpointRequests_1(ep0_out, ep0_in, &sp, c_audioControl, c_mix_ctl, c_clk_ctl);
+                            result = AudioEndpointRequests_1(ep0_out, ep0_in, &sp, c_aud_ctl, c_mix_ctl, c_clk_ctl);
                         }
 #elif (AUDIO_CLASS==1)
-                        result = AudioEndpointRequests_1(ep0_out, ep0_in, &sp, c_audioControl, c_mix_ctl, c_clk_ctl);
+                        result = AudioEndpointRequests_1(ep0_out, ep0_in, &sp, c_aud_ctl, c_mix_ctl, c_clk_ctl);
 #endif
                     }
 
@@ -878,12 +878,15 @@ void XUA_Endpoint0_loop(XUD_Result_t result, USB_SetupPacket_t sp, chanend c_ep0
                              * task - in the case where AudioHub is running on tile[0] i.e the
                              * flash tile and the USB code is running on a different tile
                              */
-                            assert((c_audioControl != null) && msg("DFU not supported when c_audioControl is null"));
+                            assert((c_aud_ctl != null) && msg("DFU not supported when c_aud_ctl is null"));
                             // Stop audio
-                            outuint(c_audioControl, SET_SAMPLE_FREQ);
-                            outuint(c_audioControl, AUDIO_STOP_FOR_DFU);
+                            outuint(c_aud_ctl, SET_SAMPLE_FREQ);
+                            outuint(c_aud_ctl, AUDIO_STOP_FOR_DFU);
                             // Handshake
-                            chkct(c_audioControl, XS1_CT_END);
+                            chkct(c_aud_ctl, XS1_CT_END);
+#else
+                            /* Directly instruct AudioHub to stop audio (and run DFUHandler() if required) */
+
 #endif
                         }
 
@@ -916,16 +919,16 @@ void XUA_Endpoint0_loop(XUD_Result_t result, USB_SetupPacket_t sp, chanend c_ep0
 #if (AUDIO_CLASS == 2) && (AUDIO_CLASS_FALLBACK)
                         if(g_curUsbSpeed == XUD_SPEED_HS)
                         {
-                            result = AudioClassRequests_2(ep0_out, ep0_in, &sp, c_audioControl, c_mix_ctl, c_clk_ctl);
+                            result = AudioClassRequests_2(ep0_out, ep0_in, &sp, c_aud_ctl, c_mix_ctl, c_clk_ctl);
                         }
                         else
                         {
-                            result = AudioClassRequests_1(ep0_out, ep0_in, &sp, c_audioControl, c_mix_ctl, c_clk_ctl);
+                            result = AudioClassRequests_1(ep0_out, ep0_in, &sp, c_aud_ctl, c_mix_ctl, c_clk_ctl);
                         }
 #elif (AUDIO_CLASS==2)
-                        result = AudioClassRequests_2(ep0_out, ep0_in, &sp, c_audioControl, c_mix_ctl, c_clk_ctl);
+                        result = AudioClassRequests_2(ep0_out, ep0_in, &sp, c_aud_ctl, c_mix_ctl, c_clk_ctl);
 #else
-                        result = AudioClassRequests_1(ep0_out, ep0_in, &sp, c_audioControl, c_mix_ctl, c_clk_ctl);
+                        result = AudioClassRequests_1(ep0_out, ep0_in, &sp, c_aud_ctl, c_mix_ctl, c_clk_ctl);
 #endif
 
 #ifdef VENDOR_AUDIO_REQS
@@ -935,7 +938,7 @@ void XUA_Endpoint0_loop(XUD_Result_t result, USB_SetupPacket_t sp, chanend c_ep0
                             result = VendorAudioRequests(ep0_out, ep0_in, sp.bRequest,
                                 sp.wValue >> 8, sp.wValue & 0xff,
                                 sp.wIndex >> 8, sp.bmRequestType.Direction,
-                                c_audioControl, c_mix_ctl, c_clk_ctl);
+                                c_aud_ctl, c_mix_ctl, c_clk_ctl);
                         }
 #endif
                     }
@@ -1122,17 +1125,17 @@ void XUA_Endpoint0_loop(XUD_Result_t result, USB_SetupPacket_t sp, chanend c_ep0
 }
 
 /* Endpoint 0 function.  Handles all requests to the device */
-void XUA_Endpoint0(chanend c_ep0_out, chanend c_ep0_in, NULLABLE_RESOURCE(chanend, c_audioControl),
+void XUA_Endpoint0(chanend c_ep0_out, chanend c_ep0_in, NULLABLE_RESOURCE(chanend, c_aud_ctl),
     chanend c_mix_ctl, chanend c_clk_ctl, chanend c_EANativeTransport_ctrl, CLIENT_INTERFACE(i_dfu, dfuInterface) VENDOR_REQUESTS_PARAMS_DEC_)
 {
     USB_SetupPacket_t sp;
-    XUA_Endpoint0_init(c_ep0_out, c_ep0_in, c_audioControl, c_mix_ctl, c_clk_ctl, c_EANativeTransport_ctrl, dfuInterface VENDOR_REQUESTS_PARAMS_);
+    XUA_Endpoint0_init(c_ep0_out, c_ep0_in, c_aud_ctl, c_mix_ctl, c_clk_ctl, c_EANativeTransport_ctrl, dfuInterface VENDOR_REQUESTS_PARAMS_);
 
     while(1)
     {
         /* Returns XUD_RES_OKAY for success, XUD_RES_RST for bus reset */
         XUD_Result_t result = USB_GetSetupPacket(ep0_out, ep0_in, &sp);
-        XUA_Endpoint0_loop(result, sp, c_ep0_out, c_ep0_in, c_audioControl, c_mix_ctl, c_clk_ctl, c_EANativeTransport_ctrl, dfuInterface VENDOR_REQUESTS_PARAMS_);
+        XUA_Endpoint0_loop(result, sp, c_ep0_out, c_ep0_in, c_aud_ctl, c_mix_ctl, c_clk_ctl, c_EANativeTransport_ctrl, dfuInterface VENDOR_REQUESTS_PARAMS_);
     }
 }
 #endif /* XUA_USB_EN*/

--- a/lib_xua/src/core/endpoint0/xua_endpoint0.c
+++ b/lib_xua/src/core/endpoint0/xua_endpoint0.c
@@ -820,7 +820,9 @@ void XUA_Endpoint0_loop(XUD_Result_t result, USB_SetupPacket_t sp, chanend c_ep0
             case USB_BMREQ_H2D_CLASS_EP:
             case USB_BMREQ_D2H_CLASS_EP:
                 {
+#if (NUM_USB_CHAN_OUT > 0) || (NUM_USB_CHAN_IN > 0)
                     unsigned epNum = sp.wIndex & 0xff;
+#endif
 
 // Ensure we only check for AUDIO EPs if enabled
 #if (NUM_USB_CHAN_IN != 0 && NUM_USB_CHAN_OUT == 0)
@@ -855,7 +857,7 @@ void XUA_Endpoint0_loop(XUD_Result_t result, USB_SetupPacket_t sp, chanend c_ep0
                     unsigned DFU_IF = INTERFACE_NUMBER_DFU;
 
                     /* DFU interface number changes based on which mode we are currently running in */
-                    if (DFU_mode_active)
+                    if(DFU_mode_active)
                     {
                         DFU_IF = 0;
                     }
@@ -866,8 +868,9 @@ void XUA_Endpoint0_loop(XUD_Result_t result, USB_SetupPacket_t sp, chanend c_ep0
 
                         /* If running in application mode stop audio */
                         /* Don't interupt audio for save and restore cmds */
-                        if ((DFU_IF == INTERFACE_NUMBER_DFU) && (sp.bRequest != XMOS_DFU_SAVESTATE) &&
-                            (sp.bRequest != XMOS_DFU_RESTORESTATE))
+                        if (!DFU_mode_active
+                                && (sp.bRequest != XMOS_DFU_SAVESTATE)
+                                && (sp.bRequest != XMOS_DFU_RESTORESTATE))
                         {
                             assert((c_audioControl != null) && msg("DFU not supported when c_audioControl is null"));
                             // Stop audio

--- a/lib_xua/src/core/endpoint0/xua_endpoint0.c
+++ b/lib_xua/src/core/endpoint0/xua_endpoint0.c
@@ -872,12 +872,19 @@ void XUA_Endpoint0_loop(XUD_Result_t result, USB_SetupPacket_t sp, chanend c_ep0
                                 && (sp.bRequest != XMOS_DFU_SAVESTATE)
                                 && (sp.bRequest != XMOS_DFU_RESTORESTATE))
                         {
+#if(NUM_USB_CHAN_OUT > 0) || (NUM_USB_CHAN_IN > 0)
+                            /* Pass command through buffering system if we have USB channels */
+                            /* We need send this command such that AudioHub runs the DFUHandler()
+                             * task - in the case where AudioHub is running on tile[0] i.e the
+                             * flash tile and the USB code is running on a different tile
+                             */
                             assert((c_audioControl != null) && msg("DFU not supported when c_audioControl is null"));
                             // Stop audio
                             outuint(c_audioControl, SET_SAMPLE_FREQ);
                             outuint(c_audioControl, AUDIO_STOP_FOR_DFU);
                             // Handshake
                             chkct(c_audioControl, XS1_CT_END);
+#endif
                         }
 
                         /* This will return 1 if reset requested */

--- a/lib_xua/src/core/endpoint0/xua_endpoint0.c
+++ b/lib_xua/src/core/endpoint0/xua_endpoint0.c
@@ -49,6 +49,7 @@
 /* Support for xCORE  channels in C */
 #define null 0
 #define outuint(c, x)   asm ("out res[%0], %1" :: "r" (c), "r" (x))
+#define outct(c, x)     asm ("outct res[%0], %1" :: "r" (c), "r" (x))
 #define chkct(c, x)     asm ("chkct res[%0], %1" :: "r" (c), "r" (x))
 #endif
 
@@ -485,7 +486,7 @@ void XUA_Endpoint0_init(chanend c_ep0_out, chanend c_ep0_in, NULLABLE_RESOURCE(c
         assert(((unsigned)c_aud_ctl != 0) && msg("DFU not supported when c_aud_ctl is null"));
 
         /* Stop audio */
-        outuint(c_aud_ctl, SET_SAMPLE_FREQ);
+        outct(c_aud_ctl, SET_SAMPLE_FREQ);
         outuint(c_aud_ctl, AUDIO_STOP_FOR_DFU);
         /* No Handshake */
         DFU_mode_active = 1;
@@ -583,7 +584,7 @@ void XUA_Endpoint0_loop(XUD_Result_t result, USB_SetupPacket_t sp, chanend c_ep0
                                     g_curStreamAlt_Out = sp.wValue;
 
                                     /* Send format of data onto buffering */
-                                    outuint(c_aud_ctl, SET_STREAM_FORMAT_OUT);
+                                    outct(c_aud_ctl, SET_STREAM_FORMAT_OUT);
                                     outuint(c_aud_ctl, g_dataFormat_Out[sp.wValue-1]);        /* Data format (PCM/DSD) */
 
                                     if(g_curUsbSpeed == XUD_SPEED_HS)
@@ -619,7 +620,7 @@ void XUA_Endpoint0_loop(XUD_Result_t result, USB_SetupPacket_t sp, chanend c_ep0
                                     g_curStreamAlt_In = sp.wValue;
 
                                     /* Send format of data onto buffering */
-                                    outuint(c_aud_ctl, SET_STREAM_FORMAT_IN);
+                                    outct(c_aud_ctl, SET_STREAM_FORMAT_IN);
                                     outuint(c_aud_ctl, g_dataFormat_In[sp.wValue-1]);        /* Data format (PCM/DSD) */
 
                                     if(g_curUsbSpeed == XUD_SPEED_HS)
@@ -882,7 +883,7 @@ void XUA_Endpoint0_loop(XUD_Result_t result, USB_SetupPacket_t sp, chanend c_ep0
                              */
                             assert((c_aud_ctl != null) && msg("DFU not supported when c_aud_ctl is null"));
                             // Stop audio
-                            outuint(c_aud_ctl, SET_SAMPLE_FREQ);
+                            outct(c_aud_ctl, SET_SAMPLE_FREQ);
                             outuint(c_aud_ctl, AUDIO_STOP_FOR_DFU);
                             // Handshake
                             chkct(c_aud_ctl, XS1_CT_END);

--- a/lib_xua/src/core/endpoint0/xua_ep0_descriptors.h
+++ b/lib_xua/src/core/endpoint0/xua_ep0_descriptors.h
@@ -353,7 +353,6 @@ StringDescTable_t g_strTable =
     .usbOutputTermStr_Audio2     = XUA_PRODUCT_EMPTY_STRING,
 #endif
 #if (AUDIO_CLASS_FALLBACK) || (AUDIO_CLASS == 1)
-
     .productStr_Audio1           = XUA_PRODUCT_EMPTY_STRING,
     .outputInterfaceStr_Audio1   = XUA_PRODUCT_EMPTY_STRING,
     .inputInterfaceStr_Audio1    = XUA_PRODUCT_EMPTY_STRING,
@@ -450,22 +449,6 @@ USB_Descriptor_Device_t devDesc_Audio1 =
 #endif
 
 #if (AUDIO_CLASS == 2)
-/* Device Descriptor for Audio Class 2.0 (Assumes High-Speed )
- *
- * The use of two configurations dates back to Windows XP (could be SP2). This
- * lacked some standards support and incorrectly parsed the full audio class 2.0
- * descriptor with its IADs (Interface Association Descriptors). The observed
- * behaviour included loading the built-in audio class 1.0 driver on some
- * interfaces (possibly the wrong ones, too), and hanging.
- *
- * Presenting a blank configuration first prevented loading the composite driver
- * and issues arising from it, while still allowing to load a vendor driver on
- * the actual configuration.
- *
- * Recent Windows subsystem can parse our class 2.0 descriptor correctly
- * (certainly Windows 7 and onwards). It may be possible to remove this
- * workaround.
- */
 USB_Descriptor_Device_t devDesc_Audio2 =
 {
     .bLength                        = sizeof(USB_Descriptor_Device_t),
@@ -702,11 +685,13 @@ typedef struct
     /* Configuration header */
     USB_Descriptor_Configuration_Header_t       Config;
 
+#if (NUM_USB_CHAN_OUT > 0) || (NUM_USB_CHAN_IN > 0)
     /* Audio Control */
     USB_Descriptor_Interface_Association_t      Audio_InterfaceAssociation;
     USB_Descriptor_Interface_t                  Audio_StdControlInterface;       /* Standard Audio Control Interface Header Descriptor */
 
     USB_CfgDesc_Audio2_CS_Control_Int           Audio_CS_Control_Int;
+#endif //#if (NUM_USB_CHAN_OUT > 0) || (NUM_USB_CHAN_IN > 0)
 #if (NUM_USB_CHAN_OUT > 0)
     /* Audio streaming: Output stream */
     USB_Descriptor_Interface_t                  Audio_Out_StreamInterface_Alt0;  /* Zero bandwith alternative */
@@ -822,6 +807,7 @@ USB_Config_Descriptor_Audio2_t cfgDesc_Audio2=
         .bMaxPower                  = _XUA_BMAX_POWER,
     },
 
+#if (NUM_USB_CHAN_OUT > 0) || (NUM_USB_CHAN_IN > 0)
     .Audio_InterfaceAssociation =
     {
         .bLength                    = sizeof(USB_Descriptor_Interface_Association_t),
@@ -935,7 +921,6 @@ USB_Config_Descriptor_Audio2_t cfgDesc_Audio2=
             .iClockSource              = offsetof(StringDescTable_t, adatClockSourceStr)/sizeof(char *),
         },
 #endif
-
 
         /* Clock Selector Descriptor (4.7.2.2) */
         .Audio_ClockSelector =
@@ -1415,6 +1400,7 @@ USB_Config_Descriptor_Audio2_t cfgDesc_Audio2=
         },
 #endif
     }, /* End of .Audio_CS_Control_Int */
+#endif //#if (NUM_USB_CHAN_OUT > 0) || (NUM_USB_CHAN_IN > 0)
 
 #if (NUM_USB_CHAN_OUT > 0)
     /* Zero bandwith alternative 0 */
@@ -2377,7 +2363,7 @@ const unsigned num_freqs_a1 = MAX(3, (0
 #define STREAMING_INTERFACES        (INPUT_INTERFACES_A1 + OUTPUT_INTERFACES_A1)
 
 /* Number of interfaces for Audio  1.0 (+1 for control ) */
-/* Note, this is different that INTERFACE_COUNT since we dont support items such as MIDI, iAP etc in UAC1 mode */
+/* Note, this is different than INTERFACE_COUNT since we dont support items such as MIDI, iAP etc in UAC1 mode */
 #define NUM_INTERFACES_A1           (1 + INPUT_INTERFACES_A1 + OUTPUT_INTERFACES_A1 + NUM_CONTROL_USB_INTERFACES + DFU_INTERFACES_A1 + HID_INTERFACES_A1)
 
 #if ((NUM_USB_CHAN_IN == 0) || defined(UAC_FORCE_FEEDBACK_EP)) && (XUA_SYNCMODE == XUA_SYNCMODE_ASYNC)

--- a/lib_xua/src/core/endpoint0/xua_ep0_uacreqs.h
+++ b/lib_xua/src/core/endpoint0/xua_ep0_uacreqs.h
@@ -6,16 +6,16 @@
 
 #include <xccompat.h>
 
-int AudioClassRequests_2(XUD_ep ep0_out, XUD_ep ep0_in, REFERENCE_PARAM(USB_SetupPacket_t, sp), NULLABLE_RESOURCE(chanend, c_audioControl),
+int AudioClassRequests_2(XUD_ep ep0_out, XUD_ep ep0_in, REFERENCE_PARAM(USB_SetupPacket_t, sp), NULLABLE_RESOURCE(chanend, c_aud_ctl),
     NULLABLE_RESOURCE(chanend, c_mix_ctl), NULLABLE_RESOURCE(chanend, c_clk_ctl));
 
-XUD_Result_t AudioClassRequests_1(XUD_ep ep0_out, XUD_ep ep0_in, REFERENCE_PARAM(USB_SetupPacket_t, sp), NULLABLE_RESOURCE(chanend, c_audioControl),
+XUD_Result_t AudioClassRequests_1(XUD_ep ep0_out, XUD_ep ep0_in, REFERENCE_PARAM(USB_SetupPacket_t, sp), NULLABLE_RESOURCE(chanend, c_aud_ctl),
     NULLABLE_RESOURCE(chanend, c_mix_ctl), NULLABLE_RESOURCE(chanend, c_clk_ctl));
 
-int AudioEndpointRequests_1(XUD_ep ep0_out, XUD_ep ep0_in, REFERENCE_PARAM(USB_SetupPacket_t, sp), NULLABLE_RESOURCE(chanend, c_audioControl),
+int AudioEndpointRequests_1(XUD_ep ep0_out, XUD_ep ep0_in, REFERENCE_PARAM(USB_SetupPacket_t, sp), NULLABLE_RESOURCE(chanend, c_aud_ctl),
     NULLABLE_RESOURCE(chanend, c_mix_ctl), NULLABLE_RESOURCE(chanend, c_clk_ctl));
 
 
-void VendorAudioRequestsInit(chanend c_audioControl, NULLABLE_RESOURCE(chanend, c_mix_ctl), NULLABLE_RESOURCE(chanend, c_clk_ctl));
+void VendorAudioRequestsInit(chanend c_aud_ctl, NULLABLE_RESOURCE(chanend, c_mix_ctl), NULLABLE_RESOURCE(chanend, c_clk_ctl));
 
 #endif

--- a/lib_xua/src/core/endpoint0/xua_ep0_uacreqs.xc
+++ b/lib_xua/src/core/endpoint0/xua_ep0_uacreqs.xc
@@ -389,7 +389,7 @@ int AudioClassRequests_2(XUD_ep ep0_out, XUD_ep ep0_in, USB_SetupPacket_t &sp, c
                                         }
                                         outct(c_clk_ctl, XS1_CT_END);
 #endif
-                                        outuint(c_aud_ctl, SET_SAMPLE_FREQ);
+                                        outct(c_aud_ctl, SET_SAMPLE_FREQ);
                                         outuint(c_aud_ctl, g_curSamFreq);
 
                                         /* Wait for handshake back - i.e. PLL locked and clocks okay */
@@ -1151,7 +1151,7 @@ int AudioEndpointRequests_1(XUD_ep ep0_out, XUD_ep ep0_in, USB_SetupPacket_t &sp
                                 g_curSamFreq = newSampleRate;
 
                                 /* Instruct audio thread to change sample freq */
-                                outuint(c_aud_ctl, SET_SAMPLE_FREQ);
+                                outct(c_aud_ctl, SET_SAMPLE_FREQ);
                                 outuint(c_aud_ctl, g_curSamFreq);
 
                                 /* Wait for handshake back - i.e. pll locked and clocks okay */

--- a/lib_xua/src/core/endpoint0/xua_ep0_uacreqs.xc
+++ b/lib_xua/src/core/endpoint0/xua_ep0_uacreqs.xc
@@ -303,7 +303,7 @@ void UpdateMixerWeight(chanend c_mix_ctl, int mix, int index, unsigned mult)
  *              XUD_RES_RST for device reset
  *              else XUD_RES_ERR
  */
-int AudioClassRequests_2(XUD_ep ep0_out, XUD_ep ep0_in, USB_SetupPacket_t &sp, chanend ?c_audioControl, chanend ?c_mix_ctl, chanend ?c_clk_ctl
+int AudioClassRequests_2(XUD_ep ep0_out, XUD_ep ep0_in, USB_SetupPacket_t &sp, chanend ?c_aud_ctl, chanend ?c_mix_ctl, chanend ?c_clk_ctl
 )
 {
     unsigned int buffer[32];
@@ -389,11 +389,11 @@ int AudioClassRequests_2(XUD_ep ep0_out, XUD_ep ep0_in, USB_SetupPacket_t &sp, c
                                         }
                                         outct(c_clk_ctl, XS1_CT_END);
 #endif
-                                        outuint(c_audioControl, SET_SAMPLE_FREQ);
-                                        outuint(c_audioControl, g_curSamFreq);
+                                        outuint(c_aud_ctl, SET_SAMPLE_FREQ);
+                                        outuint(c_aud_ctl, g_curSamFreq);
 
                                         /* Wait for handshake back - i.e. PLL locked and clocks okay */
-                                        chkct(c_audioControl, XS1_CT_END);
+                                        chkct(c_aud_ctl, XS1_CT_END);
 
                                     }
 
@@ -1103,7 +1103,7 @@ int AudioClassRequests_2(XUD_ep ep0_out, XUD_ep ep0_in, USB_SetupPacket_t &sp, c
 
 #if (AUDIO_CLASS_FALLBACK != 0) || (AUDIO_CLASS == 1)
 
-int AudioEndpointRequests_1(XUD_ep ep0_out, XUD_ep ep0_in, USB_SetupPacket_t &sp, chanend ?c_audioControl, chanend ?c_mix_ctl, chanend ?c_clk_ctl)
+int AudioEndpointRequests_1(XUD_ep ep0_out, XUD_ep ep0_in, USB_SetupPacket_t &sp, chanend ?c_aud_ctl, chanend ?c_mix_ctl, chanend ?c_clk_ctl)
 {
     /* At this point we know:
      * bmRequestType.Recipient = Endpoint
@@ -1151,11 +1151,11 @@ int AudioEndpointRequests_1(XUD_ep ep0_out, XUD_ep ep0_in, USB_SetupPacket_t &sp
                                 g_curSamFreq = newSampleRate;
 
                                 /* Instruct audio thread to change sample freq */
-                                outuint(c_audioControl, SET_SAMPLE_FREQ);
-                                outuint(c_audioControl, g_curSamFreq);
+                                outuint(c_aud_ctl, SET_SAMPLE_FREQ);
+                                outuint(c_aud_ctl, g_curSamFreq);
 
                                 /* Wait for handshake back - i.e. pll locked and clocks okay */
-                                chkct(c_audioControl, XS1_CT_END);
+                                chkct(c_aud_ctl, XS1_CT_END);
 
                                 /* Allow time for the change - feedback to stabilise */
                                 FeedbackStabilityDelay();
@@ -1188,7 +1188,7 @@ int AudioEndpointRequests_1(XUD_ep ep0_out, XUD_ep ep0_in, USB_SetupPacket_t &sp
 
 
 /* Handles the Audio Class 1.0 specific requests */
-XUD_Result_t AudioClassRequests_1(XUD_ep ep0_out, XUD_ep ep0_in, USB_SetupPacket_t &sp, chanend ?c_audioControl, chanend ?c_mix_ctl, chanend ?c_clk_ctl
+XUD_Result_t AudioClassRequests_1(XUD_ep ep0_out, XUD_ep ep0_in, USB_SetupPacket_t &sp, chanend ?c_aud_ctl, chanend ?c_mix_ctl, chanend ?c_clk_ctl
 )
 {
 #if (OUTPUT_VOLUME_CONTROL == 1) || (INPUT_VOLUME_CONTROL == 1)

--- a/lib_xua/src/core/main.xc
+++ b/lib_xua/src/core/main.xc
@@ -536,6 +536,7 @@ int main()
 #if XUA_USB_EN
 #if ((XUD_TILE == 0) && (XUA_DFU_EN == 1))
             /* Check if USB is on the flash tile (tile 0) */
+            /* Expect to be distrbuted into XUA_Endpoint0() */
             [[distribute]]
             DFUHandler(dfuInterface, null);
 #endif
@@ -555,6 +556,7 @@ int main()
                          c_sof, epTypeTableOut, epTypeTableIn, usbSpeed, xudPwrCfg);
             }
 
+#if (NUM_USB_CHAN_OUT > 0) || (NUM_USB_CHAN_IN > 0) || XUA_HID_ENABLED || defined(MIDI)
             /* Core USB audio task, buffering, USB etc */
             {
                 unsigned x;
@@ -572,7 +574,7 @@ int main()
                 asm("ldw %0, dp[clk_audio_mclk]":"=r"(x));
                 asm("setclk res[%0], %1"::"r"(p_for_mclk_count), "r"(x));
 #endif
-                /* Endpoint & audio buffering cores */
+                /* Endpoint & audio buffering cores - buffers all EP's other than 0 */
                 XUA_Buffer(
 #if (NUM_USB_CHAN_OUT > 0)
                            c_xud_out[ENDPOINT_NUMBER_OUT_AUDIO],       /* Audio Out*/
@@ -609,6 +611,7 @@ int main()
                     );
                 //:
             }
+#endif
 
             /* Endpoint 0 Core */
             {
@@ -710,7 +713,7 @@ int main()
 
 
 #if XUA_USB_EN
-#if (XUD_TILE != 0 ) && (AUDIO_IO_TILE != 0) && (XUA_DFU_EN == 1)
+#if (XUD_TILE != 0) && (AUDIO_IO_TILE != 0) && (XUA_DFU_EN == 1)
         /* Run flash code on its own - hope it gets combined */
         //#warning Running DFU flash code on its own
         on stdcore[0]: DFUHandler(dfuInterface, null);

--- a/lib_xua/src/core/main.xc
+++ b/lib_xua/src/core/main.xc
@@ -509,6 +509,8 @@ int main()
     chan c_sof;
     chan c_xud_out[ENDPOINT_COUNT_OUT];              /* Endpoint channels for XUD */
     chan c_xud_in[ENDPOINT_COUNT_IN];
+
+    /* Used to communicate controls/setting from XUA_Endpoint0() to the Audio/Buffering sub-system */
     chan c_aud_ctl;
 
 #if (!MIXER)
@@ -630,7 +632,14 @@ int main()
         {
 
             /* Audio I/O task, includes mixing etc */
-            usb_audio_io(c_mix_out
+            usb_audio_io(
+#if (NUM_USB_CHAN_OUT > 0) || (NUM_USB_CHAN_IN > 0)
+                /* Connect audio system to XUA_Buffer(); */
+                c_mix_out
+#else
+                /* Connect to XUA_Endpoint0() */
+                c_aud_ctl
+#endif
 #if (XUA_SPDIF_TX_EN) && (SPDIF_TX_TILE != AUDIO_IO_TILE)
                 , c_spdif_tx
 #endif

--- a/lib_xua/src/core/xua_commands.h
+++ b/lib_xua/src/core/xua_commands.h
@@ -24,7 +24,7 @@ enum
     CLOCK_COUNT
 };
 
-/* c_audioControl */
+/* c_aud_ctl */
 #define SET_SAMPLE_FREQ         4
 #define SET_STREAM_FORMAT_OUT   8
 #define SET_STREAM_FORMAT_IN    9


### PR DESCRIPTION
Do not run UA buffering cores when NUM_USB_CHAN_OUT & NUM_USB_CHAN_IN == 0. 

This saves 2 cores for i2s only builds (where HID/DFU etc remain active)

I renamed a channel to make its naming consistent between tasks (improved readability)