### PR TITLE
Add DFU tests

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 XMOS LIMITED.
+# Copyright 2020-2024 XMOS LIMITED.
 # This Software is subject to the terms of the XMOS Public Licence: Version 1.
 import setuptools
 
@@ -13,9 +13,9 @@ setuptools.setup(
     name='lib_xua',
     packages=setuptools.find_packages(),
     install_requires=[
-        'flake8~=3.8',
-        'pytest~=6.0',
-        'pytest-xdist~=1.34',
+        'flake8~=7.1',
+        'pytest~=8.3',
+        'pytest-xdist~=3.6',
     ],
     dependency_links=[
     ],

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-# python_version 3.7.6
+# python_version 3.11.6
+# pip_version 24.2
 #
 # The parse_version_from_requirements() function in the installPipfile.groovy
 # file of the Jenkins Shared Library uses the python_version comment to set
@@ -17,9 +18,9 @@
 # pip-install this one as editable using this repository's setup.py file.  The
 # same modules should appear in the setup.py list as given below.
 
-flake8==3.8.3
-pytest==6.0.0
-pytest-xdist==1.34.0
+flake8==7.1.1
+pytest==8.3.2
+pytest-xdist==3.6.1
 
 # Development dependencies
 #

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,3 +36,5 @@ pytest-xdist==3.6.1
 # setup.py file, e.g., '-e .' or '-e ./python' (without the quotes).
 -e ./python
 -e ./../test_support
+-e ./../hardware_test_tools
+-e ./../xtagctl

--- a/tests/xua_hw_tests/CMakeLists.txt
+++ b/tests/xua_hw_tests/CMakeLists.txt
@@ -1,0 +1,5 @@
+cmake_minimum_required(VERSION 3.21)
+include($ENV{XMOS_CMAKE_PATH}/xcommon.cmake)
+project(xua_hw_tests)
+
+add_subdirectory(test_dfu)

--- a/tests/xua_hw_tests/conftest.py
+++ b/tests/xua_hw_tests/conftest.py
@@ -1,0 +1,10 @@
+# Copyright 2024 XMOS LIMITED.
+# This Software is subject to the terms of the XMOS Public Licence: Version 1.
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--xtag-id",
+        action="store",
+        default=None,
+        help="XTAG ID to use for hardware tests",
+    )

--- a/tests/xua_hw_tests/test_dfu.py
+++ b/tests/xua_hw_tests/test_dfu.py
@@ -1,0 +1,108 @@
+# Copyright 2024 XMOS LIMITED.
+# This Software is subject to the terms of the XMOS Public Licence: Version 1.
+from pathlib import Path
+import platform
+import pytest
+import re
+import subprocess
+
+from hardware_test_tools.UaDut import UaDut
+from hardware_test_tools.UaDfuApp import UaDfuApp
+
+
+@pytest.fixture(scope="module")
+def factory_xe():
+    xe_path = Path(__file__).parent / "test_dfu" / "bin" / "factory" / "dfu_test_factory.xe"
+    assert xe_path.exists()
+    return xe_path
+
+
+def create_dfu_bin(xe_path):
+    version_re = r"XTC version: (\d+)\.(\d+)\.(\d+)"
+    ret = subprocess.run(["xcc", "--version"], capture_output=True, text=True, timeout=30)
+
+    match = re.search(version_re, ret.stdout)
+    assert match, f"Unable to get XTC Tools version: stdout={ret.stdout}"
+
+    bin_path = xe_path.parent / f"{xe_path.stem}.bin"
+    cmd = ["xflash", "--factory-version", f'{match.group(1)}.{match.group(2)}', "--upgrade", "1", xe_path, "-o", bin_path]
+    ret = subprocess.run(cmd, text=True, capture_output=True, timeout=30)
+    assert ret.returncode == 0, f"Failed to create DFU binary, cmd {cmd}\nstdout:\n{ret.stdout}\nstderr:\n{ret.stderr}"
+
+    return bin_path
+
+
+@pytest.fixture(scope="module")
+def upgrade_bin():
+    xe_path = Path(__file__).parent / "test_dfu" / "bin" / "upgrade" / "dfu_test_upgrade.xe"
+    assert xe_path.exists()
+
+    bin_path = create_dfu_bin(xe_path)
+    assert bin_path.exists()
+    return bin_path
+
+
+def cfg_list():
+    bin_dir = Path(__file__).parent / "test_dfu" / "bin"
+    if not bin_dir.exists():
+        return []
+    exclude_cfgs = ["factory", "upgrade"]
+    all_cfgs = [dir.stem for dir in bin_dir.iterdir()]
+    return [cfg for cfg in all_cfgs if cfg not in exclude_cfgs]
+
+
+def dfu_app_list():
+    if platform.system() == "Windows":
+        return ["custom"]
+    elif platform.system() == "Darwin":
+        return ["custom", "dfu-util"]
+    else:
+        # Until test subdirectories can be rearranged with XCommon CMake builds, an
+        # empty list needs to be returned here for cases where a Linux agent collects
+        # these tests from the top-level test directory (but would filter them out)
+        return []
+
+
+@pytest.mark.parametrize("cfg", cfg_list())
+@pytest.mark.parametrize("dfu_app", dfu_app_list())
+def test_dfu(pytestconfig, factory_xe, upgrade_bin, cfg, dfu_app):
+    if cfg == "i2s_only" and platform.system() == "Windows":
+        pytest.skip("i2s_only not supported on Windows")
+
+    xtag_id = pytestconfig.getoption("xtag_id")
+    assert xtag_id, "--xtag-id option must be provided on the command line"
+
+    test_xe = Path(__file__).parent / "test_dfu" / "bin" / cfg / f"dfu_test_{cfg}.xe"
+    test_bin = create_dfu_bin(test_xe)
+
+    pid = 0x16
+    in_chans = 2
+    out_chans = 2
+    prod_str = "XUA DFU Test"
+
+    # factory -> cfg -> upgrade
+    with UaDut(xtag_id, factory_xe, pid, prod_str, in_chans, out_chans, xflash=True) as dut:
+        dfu_test = UaDfuApp(dut.driver_guid, pid, dfu_app_type=dfu_app)
+        factory_version = dfu_test.get_bcd_version()
+
+        dfu_test.download(test_bin)
+        cfg_version = dfu_test.get_bcd_version()
+        assert cfg_version != factory_version
+
+        upload_file = Path(__file__).parent / "test_dfu_upload.bin"
+        dfu_test.upload(upload_file)
+        cfg_version2 = dfu_test.get_bcd_version()
+        assert cfg_version2 == cfg_version
+
+        dfu_test.download(upgrade_bin)
+        upgrade_version = dfu_test.get_bcd_version()
+        assert upgrade_version not in [factory_version, cfg_version]
+
+        dfu_test.download(upload_file)
+        upload_file.unlink()
+        upload_version = dfu_test.get_bcd_version()
+        assert upload_version == cfg_version
+
+        dfu_test.revert_factory()
+        revert_version = dfu_test.get_bcd_version()
+        assert revert_version == factory_version

--- a/tests/xua_hw_tests/test_dfu/CMakeLists.txt
+++ b/tests/xua_hw_tests/test_dfu/CMakeLists.txt
@@ -1,0 +1,58 @@
+cmake_minimum_required(VERSION 3.21)
+include($ENV{XMOS_CMAKE_PATH}/xcommon.cmake)
+project(dfu_test)
+
+set(XMOS_SANDBOX_DIR ${CMAKE_CURRENT_LIST_DIR}/../../../..)
+
+set(APP_HW_TARGET xk-audio-316-mc.xn)
+set(APP_DEPENDENT_MODULES "lib_xua"
+                          "lib_board_support(0.1.1)")
+set(APP_INCLUDES src)
+
+set(COMMON_FLAGS -O3
+                 -lquadflash
+                 -DXUA_QUAD_SPI_FLASH=1
+                 -DBOARD_SUPPORT_BOARD=XK_AUDIO_316_MC_AB)
+
+# Define app-under-test configs here
+
+set(APP_COMPILER_FLAGS_i8o8 ${COMMON_FLAGS}
+                            -DBCD_DEVICE=0x0100
+                            -DNUM_USB_CHAN_IN=8
+                            -DNUM_USB_CHAN_OUT=8
+                            -DI2S_CHANS_ADC=8
+                            -DI2S_CHANS_DAC=8)
+
+set(APP_COMPILER_FLAGS_i2s_only ${COMMON_FLAGS}
+                                -DBCD_DEVICE=0x0101
+                                -DNUM_USB_CHAN_IN=0
+                                -DNUM_USB_CHAN_OUT=0
+                                -DI2S_CHANS_ADC=8
+                                -DI2S_CHANS_DAC=8
+                                -DCODEC_MASTER=1)
+
+set(APP_COMPILER_FLAGS_hid ${COMMON_FLAGS}
+                           -DBCD_DEVICE=0x0102
+                           -DNUM_USB_CHAN_IN=8
+                           -DNUM_USB_CHAN_OUT=8
+                           -DI2S_CHANS_ADC=8
+                           -DI2S_CHANS_DAC=8
+                           -DHID_CONTROLS=1)
+
+
+# baseline configs for the testcase
+
+set(BASE_TEST_FLAGS -DNUM_USB_CHAN_IN=2
+                    -DNUM_USB_CHAN_OUT=2
+                    -DI2S_CHANS_ADC=2
+                    -DI2S_CHANS_DAC=2)
+
+set(APP_COMPILER_FLAGS_factory ${COMMON_FLAGS}
+                               ${BASE_TEST_FLAGS}
+                               -DBCD_DEVICE=0x0001)
+
+set(APP_COMPILER_FLAGS_upgrade ${COMMON_FLAGS}
+                               ${BASE_TEST_FLAGS}
+                               -DBCD_DEVICE=0x9999)
+
+XMOS_REGISTER_APP()

--- a/tests/xua_hw_tests/test_dfu/README
+++ b/tests/xua_hw_tests/test_dfu/README
@@ -15,7 +15,7 @@ the DFU download operation from the app-under-test.
 
 The testcase verifies that the DFU operations have completed
 successfully by inspecting the BCD_VERSION, so each config
-needs to define the BCD_VERSION preprocessor macroccessfully.
+needs to define the BCD_VERSION preprocessor macro.
 It is best practice to give each app-under-test a unique
 version number to allow easy identification and avoid testcases
 interfering with each other when examining test failures.

--- a/tests/xua_hw_tests/test_dfu/README
+++ b/tests/xua_hw_tests/test_dfu/README
@@ -1,0 +1,21 @@
+XUA DFU Test
+============
+
+This testcase contains multiple XUA application configs:
+ - factory
+ - upgrade
+ - other configs which are the "apps-under-test"
+
+The factory config is used as a known-good application to flash
+into the factory partition. Then the DFU download operation
+into the app-under-test can be tested.
+
+The upgrade config is used as a known-good application to test
+the DFU download operation from the app-under-test.
+
+The testcase verifies that the DFU operations have completed
+successfully by inspecting the BCD_VERSION, so each config
+needs to define the BCD_VERSION preprocessor macroccessfully.
+It is best practice to give each app-under-test a unique
+version number to allow easy identification and avoid testcases
+interfering with each other when examining test failures.

--- a/tests/xua_hw_tests/test_dfu/src/audiohw.xc
+++ b/tests/xua_hw_tests/test_dfu/src/audiohw.xc
@@ -1,0 +1,49 @@
+// Copyright 2024 XMOS LIMITED.
+// This Software is subject to the terms of the XMOS Public Licence: Version 1.
+#include "xua.h"
+#include <xk_audio_316_mc_ab/board.h>
+
+#if (XUA_SYNCMODE == XUA_SYNCMODE_SYNC)
+    #define PLL_SYNC_FREQ           (500)
+#else
+    #if (XUA_SPDIF_RX_EN || XUA_ADAT_RX_EN)
+    /* Choose a frequency the xcore can easily generate internally */
+    #define PLL_SYNC_FREQ           (300)
+    #else
+    #define PLL_SYNC_FREQ           (1000000)
+    #endif
+#endif
+
+static xk_audio_316_mc_ab_config_t config = {
+    (XUA_SYNCMODE == XUA_SYNCMODE_SYNC || XUA_SPDIF_RX_EN || XUA_ADAT_RX_EN)
+    ? ( XUA_USE_SW_PLL
+        ? CLK_PLL : CLK_CS2100 )
+    : CLK_FIXED,          // clk_mode
+    CODEC_MASTER,         // dac_is_clk_master
+    MCLK_48,              // default_mclk
+    PLL_SYNC_FREQ,        // pll_sync_freq
+    XUA_PCM_FORMAT,       // pcm_format
+    XUA_I2S_N_BITS,       // i2s_n_bits
+    I2S_CHANS_PER_FRAME,  // i2s_chans_per_frame
+};
+
+unsafe client interface i2c_master_if i_i2c_client;
+
+void board_setup()
+{
+    xk_audio_316_mc_ab_board_setup(config);
+}
+
+void AudioHwInit()
+{
+    unsafe{
+        /* Wait until global is set */
+        while(!(unsigned) i_i2c_client);
+        xk_audio_316_mc_ab_AudioHwInit((client interface i2c_master_if)i_i2c_client, config);
+    }
+}
+
+void AudioHwConfig(unsigned samFreq, unsigned mClk, unsigned dsdMode, unsigned sampRes_DAC, unsigned sampRes_ADC)
+{
+    unsafe {xk_audio_316_mc_ab_AudioHwConfig((client interface i2c_master_if)i_i2c_client, config, samFreq, mClk, dsdMode, sampRes_DAC, sampRes_ADC);}
+}

--- a/tests/xua_hw_tests/test_dfu/src/hid_controls.xc
+++ b/tests/xua_hw_tests/test_dfu/src/hid_controls.xc
@@ -1,0 +1,21 @@
+// Copyright 2024 XMOS LIMITED.
+// This Software is subject to the terms of the XMOS Public Licence: Version 1.
+#include <xs1.h>
+#include <platform.h>
+
+#include "user_hid.h"
+#include "xua_hid_report.h"
+
+#if HID_CONTROLS > 0
+
+size_t UserHIDGetData( const unsigned id, unsigned char hidData[ HID_MAX_DATA_BYTES ])
+{
+    hidData[0] = 0;
+    return 1;
+}
+
+void UserHIDInit( void )
+{
+}
+
+#endif  // HID_CONTROLS > 0

--- a/tests/xua_hw_tests/test_dfu/src/hid_report_descriptor.h
+++ b/tests/xua_hw_tests/test_dfu/src/hid_report_descriptor.h
@@ -1,0 +1,168 @@
+// Copyright 2021-2024 XMOS LIMITED.
+// This Software is subject to the terms of the XMOS Public Licence: Version 1.
+#ifndef __hid_report_descriptor_h__
+#define __hid_report_descriptor_h__
+
+#include "xua_hid_report.h"
+
+#if 0
+/* Existing static report descriptor kept for reference */
+unsigned char hidReportDescriptor[] =
+{
+    0x05, 0x0c,     /* Usage Page (Consumer Device) */
+    0x09, 0x01,     /* Usage (Consumer Control) */
+    0xa1, 0x01,     /* Collection (Application) */
+    0x15, 0x00,     /* Logical Minimum (0) */
+    0x25, 0x01,     /* Logical Maximum (1) */
+    0x09, 0xb0,     /* Usage (Play) */
+    0x09, 0xb5,     /* Usage (Scan Next Track) */
+    0x09, 0xb6,     /* Usage (Scan Previous Track) */
+    0x09, 0xe9,     /* Usage (Volume Up) */
+    0x09, 0xea,     /* Usage (Volume Down) */
+    0x09, 0xe2,     /* Usage (Mute) */
+    0x75, 0x01,     /* Report Size (1) */
+    0x95, 0x06,     /* Report Count (6) */
+    0x81, 0x02,     /* Input (Data, Var, Abs) */
+    0x95, 0x02,     /* Report Count (2) */
+    0x81, 0x01,     /* Input (Cnst, Ary, Abs) */
+    0xc0            /* End collection */
+};
+#endif
+
+/*
+ * Define non-configurable items in the HID Report descriptor.
+ */
+static const USB_HID_Short_Item_t hidCollectionApplication  = {
+    .header = HID_REPORT_SET_HEADER(1, HID_REPORT_ITEM_TYPE_MAIN, HID_REPORT_ITEM_TAG_COLLECTION),
+    .data = { 0x01, 0x00 } };
+static const USB_HID_Short_Item_t hidCollectionEnd          = {
+    .header = HID_REPORT_SET_HEADER(0, HID_REPORT_ITEM_TYPE_MAIN, HID_REPORT_ITEM_TAG_END_COLLECTION),
+    .data = { 0x00, 0x00 } };
+
+static const USB_HID_Short_Item_t hidInputConstArray        = {
+    .header = HID_REPORT_SET_HEADER(1, HID_REPORT_ITEM_TYPE_MAIN, HID_REPORT_ITEM_TAG_INPUT),
+    .data = { 0x01, 0x00 } };
+static const USB_HID_Short_Item_t hidInputDataVar           = {
+    .header = HID_REPORT_SET_HEADER(1, HID_REPORT_ITEM_TYPE_MAIN, HID_REPORT_ITEM_TAG_INPUT),
+    .data = { 0x02, 0x00 } };
+
+static const USB_HID_Short_Item_t hidLogicalMaximum0        = {
+    .header = HID_REPORT_SET_HEADER(1, HID_REPORT_ITEM_TYPE_GLOBAL, HID_REPORT_ITEM_TAG_LOGICAL_MAXIMUM),
+    .data = { 0x00, 0x00 } };
+static const USB_HID_Short_Item_t hidLogicalMaximum1        = {
+    .header = HID_REPORT_SET_HEADER(1, HID_REPORT_ITEM_TYPE_GLOBAL, HID_REPORT_ITEM_TAG_LOGICAL_MAXIMUM),
+    .data = { 0x01, 0x00 } };
+static const USB_HID_Short_Item_t hidLogicalMinimum0        = {
+    .header = HID_REPORT_SET_HEADER(1, HID_REPORT_ITEM_TYPE_GLOBAL, HID_REPORT_ITEM_TAG_LOGICAL_MINIMUM),
+    .data = { 0x00, 0x00 } };
+
+static const USB_HID_Short_Item_t hidReportCount2           = {
+    .header = HID_REPORT_SET_HEADER(1, HID_REPORT_ITEM_TYPE_GLOBAL, HID_REPORT_ITEM_TAG_REPORT_COUNT),
+    .data = { 0x02, 0x00 } };
+static const USB_HID_Short_Item_t hidReportCount6           = {
+    .header = HID_REPORT_SET_HEADER(1, HID_REPORT_ITEM_TYPE_GLOBAL, HID_REPORT_ITEM_TAG_REPORT_COUNT),
+    .data = { 0x06, 0x00 } };
+static const USB_HID_Short_Item_t hidReportSize1            = {
+    .header = HID_REPORT_SET_HEADER(1, HID_REPORT_ITEM_TYPE_GLOBAL, HID_REPORT_ITEM_TAG_REPORT_SIZE),
+    .data = { 0x01, 0x00 } };
+
+static const USB_HID_Short_Item_t hidUsageConsumerControl   = {
+    .header = HID_REPORT_SET_HEADER(1, HID_REPORT_ITEM_TYPE_LOCAL, HID_REPORT_ITEM_TAG_USAGE),
+    .data = { 0x01, 0x00 } };
+
+/*
+ * Define the HID Report Descriptor Item, Usage Page, Report ID and length for each HID Report
+ * For internal purposes, a report element with ID of 0 must be included if report IDs are not being used.
+ */
+static const USB_HID_Report_Element_t hidReportPageConsumer = {
+    .item.header = HID_REPORT_SET_HEADER(1, HID_REPORT_ITEM_TYPE_GLOBAL, HID_REPORT_ITEM_TAG_USAGE_PAGE),
+    .item.data = { USB_HID_USAGE_PAGE_ID_CONSUMER, 0x00 },
+    .location = HID_REPORT_SET_LOC( 0, 2, 0, 0 )
+};
+
+/*
+ * Define configurable items in the HID Report descriptor.
+ */
+static USB_HID_Report_Element_t hidUsageByte0Bit5   = {
+     .item.header = HID_REPORT_SET_HEADER(1, HID_REPORT_ITEM_TYPE_LOCAL, HID_REPORT_ITEM_TAG_USAGE),
+     .item.data = { 0xE2, 0x00 },
+     .location = HID_REPORT_SET_LOC(0, 0, 0, 5)
+}; // Mute
+static USB_HID_Report_Element_t hidUsageByte0Bit4   = {
+     .item.header = HID_REPORT_SET_HEADER(1, HID_REPORT_ITEM_TYPE_LOCAL, HID_REPORT_ITEM_TAG_USAGE),
+     .item.data = { 0xEA, 0x00 },
+     .location = HID_REPORT_SET_LOC(0, 0, 0, 4)
+}; // Vol-
+static USB_HID_Report_Element_t hidUsageByte0Bit3   = {
+     .item.header = HID_REPORT_SET_HEADER(1, HID_REPORT_ITEM_TYPE_LOCAL, HID_REPORT_ITEM_TAG_USAGE),
+     .item.data = { 0xE9, 0x00 },
+     .location = HID_REPORT_SET_LOC(0, 0, 0, 3)
+}; // Vol+
+static USB_HID_Report_Element_t hidUsageByte0Bit2   = {
+     .item.header = HID_REPORT_SET_HEADER(1, HID_REPORT_ITEM_TYPE_LOCAL, HID_REPORT_ITEM_TAG_USAGE),
+     .item.data = { 0xB6, 0x00 },
+     .location = HID_REPORT_SET_LOC(0, 0, 0, 2)
+}; // Scan Prev
+static USB_HID_Report_Element_t hidUsageByte0Bit1   = {
+     .item.header = HID_REPORT_SET_HEADER(1, HID_REPORT_ITEM_TYPE_LOCAL, HID_REPORT_ITEM_TAG_USAGE),
+     .item.data = { 0xB5, 0x00 },
+     .location = HID_REPORT_SET_LOC(0, 0, 0, 1)
+}; // Scan Next
+static USB_HID_Report_Element_t hidUsageByte0Bit0   = {
+     .item.header = HID_REPORT_SET_HEADER(1, HID_REPORT_ITEM_TYPE_LOCAL, HID_REPORT_ITEM_TAG_USAGE),
+     .item.data = { 0xB0, 0x00 },
+     .location = HID_REPORT_SET_LOC(0, 0, 0, 0)
+}; // Play
+
+/*
+ * List the configurable elements in the HID Report descriptor.
+ */
+static USB_HID_Report_Element_t* const hidConfigurableElements[] = {
+    &hidUsageByte0Bit0,
+    &hidUsageByte0Bit1,
+    &hidUsageByte0Bit2,
+    &hidUsageByte0Bit3,
+    &hidUsageByte0Bit4,
+    &hidUsageByte0Bit5
+};
+
+/*
+ * List HID Reports, one per Report ID. This should be a usage page item with the relevant
+ * If not using report IDs - still have one with report ID 0
+ */
+static const USB_HID_Report_Element_t* const hidReports[] = {
+    &hidReportPageConsumer
+};
+
+/*
+ * List all items in the HID Report descriptor.
+ */
+static const USB_HID_Short_Item_t* const hidReportDescriptorItems[] = {
+    &(hidReportPageConsumer.item),
+    &hidUsageConsumerControl,
+    &hidCollectionApplication,
+        &hidLogicalMinimum0,
+        &hidLogicalMaximum1,
+        &(hidUsageByte0Bit0.item),
+        &(hidUsageByte0Bit1.item),
+        &(hidUsageByte0Bit2.item),
+        &(hidUsageByte0Bit3.item),
+        &(hidUsageByte0Bit4.item),
+        &(hidUsageByte0Bit5.item),
+        &hidReportSize1,
+        &hidReportCount6,
+        &hidInputDataVar,
+        &hidLogicalMaximum0,
+        &hidReportCount2,
+        &hidInputConstArray,
+    &hidCollectionEnd
+};
+
+/*
+ * Define the number of HID Reports
+ * Due to XC not supporting designated initializers, this constant has a hard-coded value.
+ * It must equal ( sizeof hidReports / sizeof ( USB_HID_Report_Element_t* ))
+ */
+#define HID_REPORT_COUNT ( 1 )
+
+#endif // __hid_report_descriptor_h__

--- a/tests/xua_hw_tests/test_dfu/src/user_main.h
+++ b/tests/xua_hw_tests/test_dfu/src/user_main.h
@@ -1,0 +1,31 @@
+// Copyright 2024 XMOS LIMITED.
+// This Software is subject to the terms of the XMOS Public Licence: Version 1.
+#ifndef _USER_MAIN_H_
+#define _USER_MAIN_H_
+
+#ifdef __XC__
+
+#include "i2c.h"
+#include <platform.h>
+#include <xk_audio_316_mc_ab/board.h>
+
+extern unsafe client interface i2c_master_if i_i2c_client;
+extern void board_setup();
+
+
+#define USER_MAIN_DECLARATIONS \
+    interface i2c_master_if i2c[1];
+
+#define USER_MAIN_CORES on tile[0]: {\
+                                        board_setup();\
+                                        xk_audio_316_mc_ab_i2c_master(i2c);\
+                                    }\
+                        on tile[1]: {\
+                                        unsafe\
+                                        {\
+                                            i_i2c_client = i2c[0]; \
+                                        }\
+                                    }
+#endif
+
+#endif

--- a/tests/xua_hw_tests/test_dfu/src/xk-audio-316-mc.xn
+++ b/tests/xua_hw_tests/test_dfu/src/xk-audio-316-mc.xn
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Network xmlns="http://www.xmos.com"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://www.xmos.com http://www.xmos.com">
+  <Type>Board</Type>
+  <Name>xcore.ai MC Audio Board</Name>
+
+  <Declarations>
+    <Declaration>tileref tile[2]</Declaration>
+  </Declarations>
+
+  <Packages>
+    <Package id="0" Type="XS3-UnA-1024-TQ128">
+      <Nodes>
+        <Node Id="0" InPackageId="0" Type="XS3-L16A-1024" Oscillator="24MHz" SystemFrequency="600MHz" ReferenceFrequency="100MHz">
+          <Boot>
+            <Source Location="bootFlash"/>
+          </Boot>
+          <Tile Number="0" Reference="tile[0]">
+            <Port Location="XS1_PORT_1B" Name="PORT_SQI_CS"/>
+            <Port Location="XS1_PORT_1C" Name="PORT_SQI_SCLK"/>
+            <Port Location="XS1_PORT_4B" Name="PORT_SQI_SIO"/>
+
+            <!-- Various ctrl signals -->
+            <Port Location="XS1_PORT_8D"  Name="PORT_CTRL"/>
+
+            <!-- I2C -->
+            <Port Location="XS1_PORT_1L"  Name="PORT_I2C_SCL"/>
+            <Port Location="XS1_PORT_1M"  Name="PORT_I2C_SDA"/>
+
+            <!-- Clocking -->
+            <Port Location="XS1_PORT_16B" Name="PORT_MCLK_COUNT"/>
+            <Port Location="XS1_PORT_1D"  Name="PORT_MCLK_IN_USB"/>
+            <Port Location="XS1_PORT_1A"  Name="PORT_PLL_REF"/>
+
+            <!-- Audio Ports: Digital -->
+            <Port Location="XS1_PORT_1O"  Name="PORT_ADAT_IN"/>   <!-- N: Coax O: Optical -->
+            <Port Location="XS1_PORT_1N"  Name="PORT_SPDIF_IN"/>  <!-- N: Coax O: Optical -->
+
+          </Tile>
+          <Tile Number="1" Reference="tile[1]">
+            <!-- Audio Ports: I2S -->
+            <Port Location="XS1_PORT_1D"  Name="PORT_MCLK_IN"/>
+            <Port Location="XS1_PORT_16B" Name="PORT_MCLK_COUNT_2"/>
+            <Port Location="XS1_PORT_1B"  Name="PORT_I2S_LRCLK"/>
+            <Port Location="XS1_PORT_1C"  Name="PORT_I2S_BCLK"/>
+            <Port Location="XS1_PORT_1P"  Name="PORT_I2S_DAC0"/>
+            <port Location="XS1_PORT_1O"  Name="PORT_I2S_DAC1"/>
+            <port Location="XS1_PORT_1N"  Name="PORT_I2S_DAC2"/>
+            <port Location="XS1_PORT_1M"  Name="PORT_I2S_DAC3"/>
+            <Port Location="XS1_PORT_1I"  Name="PORT_I2S_ADC0"/>
+            <Port Location="XS1_PORT_1J"  Name="PORT_I2S_ADC1"/>
+            <Port Location="XS1_PORT_1K"  Name="PORT_I2S_ADC2"/>
+            <Port Location="XS1_PORT_1L"  Name="PORT_I2S_ADC3"/>
+
+            <!-- Audio Ports: Digital -->
+            <Port Location="XS1_PORT_1G"  Name="PORT_ADAT_OUT"/>  <!-- A: Coax G: Optical -->
+            <Port Location="XS1_PORT_1A"  Name="PORT_SPDIF_OUT"/> <!-- A: Coax G: Optical -->
+
+            <!-- MIDI -->
+            <Port Location="XS1_PORT_1F"  Name="PORT_MIDI_IN"/>
+            <Port Location="XS1_PORT_4C"  Name="PORT_MIDI_OUT"/>  <!-- bit[0] -->
+
+          </Tile>
+        </Node>
+      </Nodes>
+    </Package>
+  </Packages>
+  <Nodes>
+    <Node Id="2" Type="device:" RoutingId="0x8000">
+      <Service Id="0" Proto="xscope_host_data(chanend c);">
+        <Chanend Identifier="c" end="3"/>
+      </Service>
+    </Node>
+  </Nodes>
+  <Links>
+    <Link Encoding="2wire" Delays="5clk" Flags="XSCOPE">
+      <LinkEndpoint NodeId="0" Link="XL0"/>
+      <LinkEndpoint NodeId="2" Chanend="1"/>
+    </Link>
+  </Links>
+  <ExternalDevices>
+      <Device NodeId="0" Tile="0" Class="SQIFlash" Name="bootFlash" PageSize="256" SectorSize="4096" NumPages="16384">
+      <Attribute Name="PORT_SQI_CS" Value="PORT_SQI_CS"/>
+      <Attribute Name="PORT_SQI_SCLK"   Value="PORT_SQI_SCLK"/>
+      <Attribute Name="PORT_SQI_SIO"  Value="PORT_SQI_SIO"/>
+    </Device>
+  </ExternalDevices>
+  <JTAGChain>
+    <JTAGDevice NodeId="0"/>
+  </JTAGChain>
+
+</Network>

--- a/tests/xua_hw_tests/test_dfu/src/xua_conf.h
+++ b/tests/xua_hw_tests/test_dfu/src/xua_conf.h
@@ -1,0 +1,23 @@
+// Copyright 2024 XMOS LIMITED.
+// This Software is subject to the terms of the XMOS Public Licence: Version 1.
+#ifndef _XUA_CONF_H_
+#define _XUA_CONF_H_
+
+#define XUD_TILE (0)
+#define AUDIO_IO_TILE (1)
+
+#define MCLK_441 (512 * 44100)
+#define MCLK_48 (512 * 48000)
+
+#define XUA_DFU_EN (1)
+
+#define PRODUCT_STR "XUA DFU Test"
+#define PID_AUDIO_2 (0x0016)
+
+#ifndef BCD_DEVICE
+#error BCD_DEVICE must be defined in APP_COMPILER_FLAGS_<cfg>
+#endif
+
+#include "user_main.h"
+
+#endif


### PR DESCRIPTION
I wanted to restructure the tests so that, alongside xua_unit_tests, there is an xua_sim_tests directory (containing all the current tests other than xua_unit_tests). Then xua_hw_tests could be added. These separate directories make it easier to run the required tests in each Jenkins stage without resorting to pytest keywords or markers. However, the existing tests use XCommon and that has a limit to the number of nested directories to get to your app. So once these tests are converted to XCommon CMake, this restructure can take place, but for now I'll just add a keyword filter to exclude the tests I don't want to run.

The CI job uses Python 3.7.6, but a newer version is needed for Windows hardware testing. I can't update to 3.12 because we are still building host apps on x86 MacOS hardware (we need xmosdfu for sw_usb_audio), so I've updated to 3.11. This also required an update to the pip installed modules, which then also needed some modifications in the conftest.py for xua_unit_tests, including some cleanup to fix pytest warnings so we are clear for deprecation warnings to the next major version.

Added test_dfu hardware test to perform DFU operations with different XUA configs. There are three configs so far: a standard analogue config, an I2S-only config, and a config with HID enabled. These are tested with dfu-util and xmosdfu on MacOS, and using Thesycon dfucons on Windows.