### PR TITLE
Changes for updating  to Thesycon driver v5.70

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,7 @@ UNRELEASED
   * FIXED:     DFU support with UAC1.0
   * FIXED:     baInterfaceNr field in MIDI Class-specific AC Interface Descriptor to specify
     the correct MIDI streaming interface number
+  * CHANGED:   Default value of FLASH_MAX_UPGRADE_SIZE to 512 KB
 
 4.2.0
 -----

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,8 @@ UNRELEASED
   * CHANGED:   Added default value (1) for XUA_QUAD_SPI_FLASH
   * FIXED:     Build issue when XUA_NUM_PDM_MICS > 0
   * FIXED:     DFU support with UAC1.0
+  * FIXED:     baInterfaceNr field in MIDI Class-specific AC Interface Descriptor to specify
+    the correct MIDI streaming interface number
 
 4.2.0
 -----

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,7 @@ UNRELEASED
     descriptor
   * CHANGED:   xmosdfu app to use DFU_DETACH
   * CHANGED:   xmosdfu app to send XMOS_DFU_REVERTFACTORY as bmRequestType.Type = Vendor
+  * CHANGED:   xmosdfu app command line for specifying runtime and DFU mode PIDs
   * CHANGED:   Limit HS_STREAM_FORMAT_OUTPUT_1/2/3_MAXPACKETSIZE to 1024 bytes to fix
     bcdUSB version 2.01 USB device supporting a sampling rate of 192KHz not enumerating
     on Windows

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,7 +6,7 @@ pipeline {
   agent none
   environment {
     REPO = 'lib_xua'
-    VIEW = getViewName(REPO)
+    VIEW = 'lib_xua_dfu_testing'
     TOOLS_VERSION = "15.2.1"    // For unit tests
   }
   options {
@@ -108,7 +108,7 @@ pipeline {
         }
         stage('Build Windows host app') {
           agent {
-            label 'x86_64&&windows'
+            label 'x86_64&&windows&&usb_audio'
           }
           steps {
             dir("${REPO}") {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,7 +6,7 @@ pipeline {
   agent none
   environment {
     REPO = 'lib_xua'
-    VIEW = 'lib_xua_dfu_testing'
+    VIEW = getViewName(REPO)
     TOOLS_VERSION = "15.2.1"    // For unit tests
   }
   options {

--- a/host_usb_mixer_control/host_usb_mixer_control.vcxproj
+++ b/host_usb_mixer_control/host_usb_mixer_control.vcxproj
@@ -58,8 +58,8 @@
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
   <ImportGroup Label="Shared">
-    <Import Project="$(SDKPath)\source\tusbaudioapi_inc\tusbaudioapi_inc_vs2019.vcxitems" Label="Shared" />
-    <Import Project="$(SDKPath)\source\libwn_min\_libwn_min_vs2019.vcxitems" Label="Shared" />
+    <Import Project="$(SDKPath)\source\tusbaudioapi_inc\tusbaudioapi_inc_vs2022.vcxitems" Label="Shared" />
+    <Import Project="$(SDKPath)\source\libwn_min\_libwn_min_vs2022.vcxitems" Label="Shared" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />

--- a/lib_xua/host/xmosdfu/src/xmosdfu.cpp
+++ b/lib_xua/host/xmosdfu/src/xmosdfu.cpp
@@ -26,14 +26,6 @@ void Sleep(unsigned milliseconds) {
 
 #include "libusb.h"
 
-
-typedef struct device_pid_t
-{
-    const char *device_name;
-    unsigned int pid;
-} device_pid_t;
-
-
 unsigned int XMOS_DFU_IF = 0;
 static int dfu_timeout = 5000; // 5s
 
@@ -52,10 +44,7 @@ static int dfu_timeout = 5000; // 5s
 #define DFU_ABORT 6
 
 // XMOS alternate setting requests
-#define XMOS_DFU_RESETDEVICE          0xf0
 #define XMOS_DFU_REVERTFACTORY        0xf1
-#define XMOS_DFU_RESETINTODFU         0xf2
-#define XMOS_DFU_RESETFROMDFU         0xf3
 
 #define bInterfaceProtocol_RUNTIME (1)
 #define bInterfaceProtocol_DFU (2)
@@ -172,27 +161,9 @@ static int find_xmos_device(unsigned int list)
 }
 
 
-int xmos_dfu_resetdevice(void)
-{
-    libusb_control_transfer(devh, USB_BMREQ_H2D_CLASS_INT, XMOS_DFU_RESETDEVICE, 0, 0, NULL, 0, 0);
-    return 0;
-}
-
 int xmos_dfu_revertfactory(void)
 {
     libusb_control_transfer(devh, USB_BMREQ_H2D_VENDOR_INT, XMOS_DFU_REVERTFACTORY, 0, 0, NULL, 0, 0);
-    return 0;
-}
-
-int xmos_dfu_resetintodfu(unsigned int interface)
-{
-    libusb_control_transfer(devh, USB_BMREQ_H2D_CLASS_INT, XMOS_DFU_RESETINTODFU, 0, interface, NULL, 0, 0);
-    return 0;
-}
-
-int xmos_dfu_resetfromdfu(unsigned int interface)
-{
-    libusb_control_transfer(devh, USB_BMREQ_H2D_CLASS_INT, XMOS_DFU_RESETFROMDFU, 0, interface, NULL, 0, 0);
     return 0;
 }
 
@@ -408,8 +379,6 @@ static void print_usage(const char *program_name, const char *error_msg)
     fprintf(stderr, "       --download <firmware> : write an upgrade image\n");
     fprintf(stderr, "       --upload <firmware>   : read the upgrade image\n");
     fprintf(stderr, "       --revertfactory       : revert to the factory image\n");
-    fprintf(stderr, "       --savecustomstate     : \n");
-    fprintf(stderr, "       --restorecustomstate  : \n");
 
     exit(1);
 }

--- a/lib_xua/host/xmosdfu/src/xmosdfu.cpp
+++ b/lib_xua/host/xmosdfu/src/xmosdfu.cpp
@@ -79,6 +79,7 @@ static int probe_configuration(libusb_device *dev, struct libusb_device_descript
     if (ret != 0) {
         return -1;
     }
+    int found_dfu_itf = 0;
     if (config_desc != NULL)
     {
         //printf("bNumInterfaces: %d\n", config_desc->bNumInterfaces);
@@ -104,7 +105,8 @@ static int probe_configuration(libusb_device *dev, struct libusb_device_descript
                         {
                             printf("Opening DFU capable USB device, [%04x:%04x], Runtime mode.\n", desc.idVendor, desc.idProduct);
                             device_bInterfaceProtocol = inter_desc->bInterfaceProtocol;
-                            return 0;
+                            found_dfu_itf = 1;
+                            break;
                         }
                     }
                 }
@@ -122,14 +124,16 @@ static int probe_configuration(libusb_device *dev, struct libusb_device_descript
                         {
                             printf("Opening DFU capable USB device, [%04x:%04x], DFU mode.\n", desc.idVendor, desc.idProduct);
                             device_bInterfaceProtocol = inter_desc->bInterfaceProtocol;
-                            return 0;
+                            found_dfu_itf = 1;
+                            break;
                         }
                     }
                 }
             }
         }
+        libusb_free_config_descriptor(config_desc);
     }
-    return -1;
+    return found_dfu_itf ? 0 : -1;
 }
 
 static int find_xmos_device(unsigned int list)

--- a/lib_xua/src/core/endpoint0/xua_ep0_descriptors.h
+++ b/lib_xua/src/core/endpoint0/xua_ep0_descriptors.h
@@ -2013,7 +2013,7 @@ USB_Config_Descriptor_Audio2_t cfgDesc_Audio2=
     0x09,                                 /* 5 wTotalLength : Total size of class specific descriptors. (field size 2 bytes) */
     0x00,                                 /* 6 wTotalLength */
     0x01,                                 /* 7 bInCollection : Number of streaming interfaces. (field size 1 bytes) */
-    0x01,                                 /* 8 baInterfaceNr(1) : MIDIStreaming interface 1 belongs to this AudioControl interface */
+    INTERFACE_NUMBER_MIDI_STREAM,         /* 8 baInterfaceNr : MIDIStreaming interface that belongs to this AudioControl interface */
 
 /* Table B-5: MIDI Adapter Standard MS Interface Descriptor */
     0x09,                                 /* 0 bLength : Size of this descriptor, in bytes. (field size 1 bytes) */

--- a/lib_xua/src/dfu/flash_interface.c
+++ b/lib_xua/src/dfu/flash_interface.c
@@ -22,7 +22,7 @@
  * and 5 seconds is just over 300KB
  */
 #ifndef FLASH_MAX_UPGRADE_SIZE
-#define FLASH_MAX_UPGRADE_SIZE (128 * 1024)
+#define FLASH_MAX_UPGRADE_SIZE (512 * 1024)
 #endif
 
 #define FLASH_ERROR() do {} while(0)

--- a/tests/xua_hw_tests/test_dfu.py
+++ b/tests/xua_hw_tests/test_dfu.py
@@ -75,13 +75,13 @@ def test_dfu(pytestconfig, factory_xe, upgrade_bin, cfg, dfu_app):
     test_xe = Path(__file__).parent / "test_dfu" / "bin" / cfg / f"dfu_test_{cfg}.xe"
     test_bin = create_dfu_bin(test_xe)
 
-    pid = 0x16
+    pid = (0x16, 0xD016)
     in_chans = 2
     out_chans = 2
     prod_str = "XUA DFU Test"
 
     # factory -> cfg -> upgrade
-    with UaDut(xtag_id, factory_xe, pid, prod_str, in_chans, out_chans, xflash=True) as dut:
+    with UaDut(xtag_id, factory_xe, pid[0], prod_str, in_chans, out_chans, xflash=True) as dut:
         dfu_test = UaDfuApp(dut.driver_guid, pid, dfu_app_type=dfu_app)
         factory_version = dfu_test.get_bcd_version()
 

--- a/tests/xua_hw_tests/test_dfu.py
+++ b/tests/xua_hw_tests/test_dfu.py
@@ -52,9 +52,7 @@ def cfg_list():
 
 
 def dfu_app_list():
-    if platform.system() == "Windows":
-        return ["custom"]
-    elif platform.system() == "Darwin":
+    if platform.system() == "Windows" or platform.system() == "Darwin":
         return ["custom", "dfu-util"]
     else:
         # Until test subdirectories can be rearranged with XCommon CMake builds, an

--- a/tests/xua_hw_tests/test_dfu.py
+++ b/tests/xua_hw_tests/test_dfu.py
@@ -82,7 +82,7 @@ def test_dfu(pytestconfig, factory_xe, upgrade_bin, cfg, dfu_app):
 
     # factory -> cfg -> upgrade
     with UaDut(xtag_id, factory_xe, pid[0], prod_str, in_chans, out_chans, xflash=True) as dut:
-        dfu_test = UaDfuApp(dut.driver_guid, pid, dfu_app_type=dfu_app)
+        dfu_test = UaDfuApp(pid, dfu_app_type=dfu_app)
         factory_version = dfu_test.get_bcd_version()
 
         dfu_test.download(test_bin)

--- a/tests/xua_hw_tests/test_dfu.py
+++ b/tests/xua_hw_tests/test_dfu.py
@@ -64,9 +64,6 @@ def dfu_app_list():
 @pytest.mark.parametrize("cfg", cfg_list())
 @pytest.mark.parametrize("dfu_app", dfu_app_list())
 def test_dfu(pytestconfig, factory_xe, upgrade_bin, cfg, dfu_app):
-    if cfg == "i2s_only" and platform.system() == "Windows":
-        pytest.skip("i2s_only not supported on Windows")
-
     xtag_id = pytestconfig.getoption("xtag_id")
     assert xtag_id, "--xtag-id option must be provided on the command line"
 

--- a/tests/xua_hw_tests/test_dfu/src/xua_conf.h
+++ b/tests/xua_hw_tests/test_dfu/src/xua_conf.h
@@ -13,6 +13,7 @@
 
 #define PRODUCT_STR "XUA DFU Test"
 #define PID_AUDIO_2 (0x0016)
+#define DFU_PID (0xD000 + PID_AUDIO_2)
 
 #ifndef BCD_DEVICE
 #error BCD_DEVICE must be defined in APP_COMPILER_FLAGS_<cfg>


### PR DESCRIPTION
Changes:
- mixer app compiling with Thesycon v5.70 tusbaudio SDK.
- Updated xmosdfu app to allow specifying different runtime and DFU mode PIDs
- Updated dfu tests to have different PIDs for runtime and DFU mode.
- Fixed baInterfaceNr field in MIDI Class-specific AC Interface Descriptor to specify INTERFACE_NUMBER_MIDI_STREAM