### PR TITLE
 No longer use a mclk port when its not required

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,11 +7,13 @@ lib_xua change log
   * ADDED:     Support for DFU 1.1 DFU_DETACH with bitWillDetach set to 1
   * ADDED:     Enumerate with the DFU interface as WINUSB compatible. This is
     done by updating the bcdUSB version to 2.01 and providing the BOS and
-    MSOS2.0 descriptors listing WINUSB compatibility the time of enumeration
+    MSOS2.0 descriptors listing WINUSB compatibility at enumeration
   * ADDED:     Support for XMOS_DFU_REVERTFACTORY arriving as a
     USB_BMREQ_H2D_VENDOR_INT request to work with the latest Thesycon DFU driver
     on Windows
   * ADDED:     Support for building the xmosdfu application on MacOS arm64
+  * ADDED:     MIDI support with UAC1.0
+  * ADDED:     DFU support with UAC1.0
   * CHANGED:   By default, enumerate with iSerialNumber set to None(0) in the
     device descriptor
   * CHANGED:   xmosdfu app to use DFU_DETACH
@@ -22,19 +24,18 @@ lib_xua change log
     to fix bcdUSB version 2.01 USB device supporting a sampling rate of 192KHz
     not enumerating on Windows
   * CHANGED:   Added default value (1) for XUA_QUAD_SPI_FLASH
-  * FIXED:     Build issue when XUA_NUM_PDM_MICS > 0
-  * FIXED:     DFU support with UAC1.0
-  * FIXED:     baInterfaceNr field in MIDI Class-specific AC Interface
-    Descriptor to specify the correct MIDI streaming interface number
   * CHANGED:   Default value of FLASH_MAX_UPGRADE_SIZE to 512 KB
-  * ADDED:     MIDI support with UAC1.0
   * CHANGED:   Build examples using XCommon CMake instead of XCommon
   * CHANGED:   AN00248 now targets XK-EVK-XU316 and uses mic_array version 5
     (new API)
-  * REMOVED:   Support for PDM mics in XS2 targets (requires xcore.ai). Can use
-    lib_xua version <=4.2.0 for XS2 (xcore-200) targets
   * CHANGED:   Examples use lib_board_support for XK-AUDIO-316-MC-AB support
     code
+  * CHANGED:   Master clock port no longer used if not required, for example
+    when using I2S slave with USB disabled
+  * FIXED:     Build issue when XUA_NUM_PDM_MICS > 0
+  * FIXED:     baInterfaceNr field in MIDI Class-specific AC Interface
+    Descriptor to specify the correct MIDI streaming interface number
+  * REMOVED:   Support for PDM mics for xcore-200 targets
 
   * Changes to dependencies:
 

--- a/lib_xua/api/xua.h
+++ b/lib_xua/api/xua.h
@@ -1,9 +1,27 @@
-// Copyright 2017-2023 XMOS LIMITED.
+// Copyright 2017-2024 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 #ifndef _XUA_H_
 #define _XUA_H_
 
 #include <xs1.h>
+
+#ifndef __ASSEMBLER__
+#include <xccompat.h>
+
+/* Missing items from xccompat.h */
+#if defined( __XC__)
+    #define NULLABLE_CLIENT_INTERFACE(tag, name) client interface tag ?name
+    #define NULLABLE_SERVER_INTERFACE(tag, name) server interface tag ?name
+    typedef in port in_port_t;
+    typedef out port out_port_t;
+#elif defined(__STDC__) || defined(__DOXYGEN__)
+    #define NULLABLE_CLIENT_INTERFACE(type, name) unsigned *name
+    #define NULLABLE_SERVER_INTERFACE(tag, name) unsigned *name
+    typedef unsigned clock;
+    typedef unsigned in_port_t;
+    typedef unsigned out_port_t;
+#endif
+#endif
 
 #include "xua_conf_full.h"
 

--- a/lib_xua/api/xua_audiohub.h
+++ b/lib_xua/api/xua_audiohub.h
@@ -5,22 +5,17 @@
 
 #if(defined __XC__ || defined __DOXYGEN__)
 
-#include "xccompat.h"
-#include "xs1.h"
+#include "xua.h"
 
 #if XUA_USB_EN
 #include "dfu_interface.h"
 #endif
-
-#include "xua_clocking.h"
-
 
 #if CODEC_MASTER
     #define i2s_clk_port_type in_buffered_port_32_t
 #else
     #define i2s_clk_port_type out_buffered_port_32_t
 #endif
-
 
 /** The audio driver thread.
  *
@@ -34,7 +29,7 @@
  *
  *  \param clk_audio_bclk       Nullable clockblock to be clocked from i2s bit clock
  *
- *  \param p_mclk_in            Master clock inport port (must be 1-bit)
+ *  \param p_mclk_in            Master clock inport port (must be 1-bit). Use null when xcore is slave
  *
  *  \param p_lrclk              Nullable port for I2S sample clock
  *
@@ -61,11 +56,11 @@ void XUA_AudioHub(
     NULLABLE_RESOURCE(chanend, c_aud),
     NULLABLE_RESOURCE(clock, clk_audio_mclk),
     NULLABLE_RESOURCE(clock, clk_audio_bclk),
-    in_port_t p_mclk_in
-    , NULLABLE_RESOURCE(i2s_clk_port_type, p_lrclk)
-    , NULLABLE_RESOURCE(i2s_clk_port_type, p_bclk)
-    , NULLABLE_ARRAY_OF_SIZE(out_buffered_port_32_t, p_i2s_dac, I2S_WIRES_DAC)
-    , NULLABLE_ARRAY_OF_SIZE(in_buffered_port_32_t, p_i2s_adc, I2S_WIRES_ADC)
+    NULLABLE_RESOURCE(in_port_t, p_mclk_in),
+    NULLABLE_RESOURCE(i2s_clk_port_type, p_lrclk),
+    NULLABLE_RESOURCE(i2s_clk_port_type, p_bclk),
+    NULLABLE_ARRAY_OF_SIZE(out_buffered_port_32_t, p_i2s_dac, I2S_WIRES_DAC),
+    NULLABLE_ARRAY_OF_SIZE(in_buffered_port_32_t, p_i2s_adc, I2S_WIRES_ADC)
 #if (XUA_SPDIF_TX_EN) || defined(__DOXYGEN__)
     , chanend c_spdif_tx
 #endif
@@ -81,7 +76,6 @@ void XUA_AudioHub(
 #if (XUA_NUM_PDM_MICS > 0 || defined(__DOXYGEN__))
     , chanend c_pdm_in
 #endif
-
 );
 
 void SpdifTxWrapper(chanend c_spdif_tx);

--- a/lib_xua/api/xua_conf_default.h
+++ b/lib_xua/api/xua_conf_default.h
@@ -2,10 +2,9 @@
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 /*
  * @brief       Defines relating to device configuration and customisation of lib_xua
- * @author      Ross Owen, XMOS Limited
  */
-#ifndef __XUA_CONF_DEFAULT_H__
-#define __XUA_CONF_DEFAULT_H__
+#ifndef _XUA_CONF_DEFAULT_H_
+#define _XUA_CONF_DEFAULT_H_
 
 #ifdef __xua_conf_h_exists__
     #include "xua_conf.h"
@@ -58,7 +57,7 @@
 #endif
 
 /*
- * Channel based defines
+ * Audio channel based defines
  */
 
 /**
@@ -717,7 +716,7 @@
  * @brief Device firmware version number in Binary Coded Decimal format: 0xJJMN where JJ: major, M: minor, N: sub-minor version number.
  */
 #ifndef BCD_DEVICE_J
-#define BCD_DEVICE_J             (1)
+#define BCD_DEVICE_J             (4)
 #endif
 
 /**
@@ -1661,12 +1660,3 @@ enum USBEndpointNumber_Out
 #define WINUSB_DEVICE_INTERFACE_GUID               "{89C14132-D389-4FF7-944E-2E33379BB59D}"
 #endif
 
-#ifdef __XC__
-    #define NULLABLE_CLIENT_INTERFACE(tag, name) client interface tag ?name
-    #define NULLABLE_SERVER_INTERFACE(tag, name) server interface tag ?name
-    #define in_port_t in port
-#else
-    #define NULLABLE_CLIENT_INTERFACE(type, name) unsigned *name
-    #define NULLABLE_SERVER_INTERFACE(tag, name) unsigned *name
-    #define in_port_t unsigned
-#endif

--- a/lib_xua/src/core/audiohub/audiohub_dsd.h
+++ b/lib_xua/src/core/audiohub/audiohub_dsd.h
@@ -1,18 +1,9 @@
-// Copyright 2018-2023 XMOS LIMITED.
+// Copyright 2018-2024 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 
 #if (DSD_CHANS_DAC != 0)
 extern buffered out port:32 p_dsd_dac[DSD_CHANS_DAC];
 extern buffered out port:32 p_dsd_clk;
-#endif
-
-/* I2S Data I/O*/
-#if (I2S_CHANS_DAC != 0)
-extern buffered out port:32 p_i2s_dac[I2S_WIRES_DAC];
-#endif
-
-#if (I2S_CHANS_ADC != 0)
-extern buffered in port:32  p_i2s_adc[I2S_WIRES_ADC];
 #endif
 
 /* This function performs the DSD native loop and outputs a 32b DSD stream per loop */

--- a/lib_xua/src/core/audiohub/xua_audiohub.xc
+++ b/lib_xua/src/core/audiohub/xua_audiohub.xc
@@ -627,7 +627,7 @@ static void dummy_deliver(chanend ?c_out, unsigned &command)
  #endif
 
 void XUA_AudioHub(chanend ?c_aud, clock ?clk_audio_mclk, clock ?clk_audio_bclk,
-    in port p_mclk_in,
+    in port ?p_mclk_in,
     buffered _XUA_CLK_DIR port:32 ?p_lrclk,
     buffered _XUA_CLK_DIR port:32 ?p_bclk,
     buffered out port:32 (&?p_i2s_dac)[I2S_WIRES_DAC],
@@ -663,9 +663,8 @@ void XUA_AudioHub(chanend ?c_aud, clock ?clk_audio_mclk, clock ?clk_audio_bclk,
     unsigned firstRun = 1;
 
     /* Clock master clock-block from master-clock port */
-    /* Note, marked unsafe since other cores may be using this mclk port */
-    configure_clock_src(clk_audio_mclk, p_mclk_in);
-
+    if(!isnull(p_mclk_in))
+        configure_clock_src(clk_audio_mclk, p_mclk_in);
 
 #if (DSD_CHANS_DAC > 0)
     /* Make sure the DSD ports are on and buffered - just in case they are not shared with I2S */

--- a/lib_xua/src/core/ports/audioports.c
+++ b/lib_xua/src/core/ports/audioports.c
@@ -1,4 +1,4 @@
-// Copyright 2013-2023 XMOS LIMITED.
+// Copyright 2013-2024 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 
 #include <xs1.h>
@@ -34,32 +34,33 @@ void EnableBufferedPort(port p, unsigned transferWidth)
 /* C wrapper for ConfigAudioPorts() to handle DSD ports */
 void ConfigAudioPortsWrapper(
 #if (I2S_CHANS_DAC != 0) || (DSD_CHANS_DAC != 0)
-                port p_dac[], int numPortsDac,
+    port p_dac[], int numPortsDac,
 #endif
 
 #if (I2S_CHANS_ADC != 0)
-                port p_adc[], int numPortsAdc,
+    port p_adc[], int numPortsAdc,
 #endif
 
 #if (I2S_CHANS_DAC != 0) || (I2S_CHANS_ADC != 0)
-                port p_lrclk,
-                port p_bclk,
+    port p_lrclk,
+    port p_bclk,
 #endif
-                port p_mclk_in, clock clk_audio_bclk, unsigned int divide, unsigned curSamFreq)
+    NULLABLE_RESOURCE(in_port_t,  p_mclk_in),
+    clock clk_audio_bclk, unsigned int divide, unsigned curSamFreq)
 {
         ConfigAudioPorts(
 #if (I2S_CHANS_DAC != 0) || (DSD_CHANS_DAC != 0)
-                p_dac,
-                numPortsDac,
+            p_dac,
+            numPortsDac,
 #endif
 #if (I2S_CHANS_ADC != 0)
-                p_adc,
-                numPortsAdc,
+            p_adc,
+            numPortsAdc,
 #endif
 #if (I2S_CHANS_DAC != 0) || (I2S_CHANS_ADC != 0)
-                p_lrclk,
-                p_bclk,
+            p_lrclk,
+            p_bclk,
 #endif
-                p_mclk_in, clk_audio_bclk, divide, curSamFreq);
+            p_mclk_in, clk_audio_bclk, divide, curSamFreq);
 }
 

--- a/lib_xua/src/core/ports/audioports.h
+++ b/lib_xua/src/core/ports/audioports.h
@@ -1,104 +1,55 @@
-// Copyright 2011-2023 XMOS LIMITED.
+// Copyright 2011-2024 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 #ifndef _AUDIOPORTS_H_
 #define _AUDIOPORTS_H_
 
 #include <xccompat.h>
-#ifdef __STDC__
-typedef unsigned clock;
-#endif
+
+
 #include "xua.h"
 
-#ifdef __XC__
 void ConfigAudioPorts(
 #if (I2S_CHANS_DAC != 0) || (DSD_CHANS_DAC != 0)
-                buffered out port:32 p_i2s_dac[],
-                int numDacPorts,
-
+    out_buffered_port_32_t p_i2s_dac[],
+    int numDacPorts,
 #endif
-
 #if (I2S_CHANS_ADC != 0)
-                buffered in port:32  p_i2s_adc[],
-                int numAdcPorts,
+    in_buffered_port_32_t p_i2s_adc[],
+    int numAdcPorts,
 #endif
-
 #if (I2S_CHANS_DAC != 0) || (I2S_CHANS_ADC != 0)
 #if (CODEC_MASTER == 0)
-                buffered out port:32 ?p_lrclk,
-                buffered out port:32 p_bclk,
+    NULLABLE_RESOURCE(out_buffered_port_32_t, p_lrclk),
+    out_buffered_port_32_t p_bclk,
 #else
-                in port ?p_lrclk,
-                in port p_bclk,
+    NULLABLE_RESOURCE(in_port_t, p_lrclk),
+    in_port_t p_bclk,
 #endif
 #endif
-                in port p_mclk_in, clock clk_audio_bclk, unsigned int divide, unsigned int curSamFreq);
-#else
+    NULLABLE_RESOURCE(in_port_t,  p_mclk_in),
+    clock clk_audio_bclk, unsigned int divide, unsigned int curSamFreq);
 
-void ConfigAudioPorts(
-#if (I2S_CHANS_DAC != 0) || (DSD_CHANS_DAC != 0)
-                port p_i2s_dac[],
-                int numDacPorts,
-#endif
-
-#if (I2S_CHANS_ADC != 0)
-                port p_i2s_adc[],
-                int numAdcPorts,
-#endif
-
-#if (I2S_CHANS_DAC != 0) || (I2S_CHANS_ADC != 0)
-#if (CODEC_MASTER == 0)
-                port p_lrclk,
-                port p_bclk,
-#else
-                port p_lrclk,
-                port p_bclk,
-#endif
-#endif
-                port p_mclk_in, clock clk_audio_bclk, unsigned int divide, unsigned int curSamFreq);
-
-
-#endif /* __XC__*/
-
-
-#ifdef __XC__
-void ConfigAudioPortsWrapper(
-#if (I2S_CHANS_DAC != 0) || (DSD_CHANS_DAC != 0)
-                buffered out port:32 p_i2s_dac[], int numPortsDAC,
-#endif
-
-#if (I2S_CHANS_ADC != 0)
-                buffered in port:32  p_i2s_adc[], int numPortsADC,
-#endif
-
-#if (I2S_CHANS_DAC != 0) || (I2S_CHANS_ADC != 0)
-#if (CODEC_MASTER == 0)
-                buffered out port:32 ?p_lrclk,
-                buffered out port:32 p_bclk,
-#else
-                buffered in port:32 ?p_lrclk,
-                buffered in port:32 p_bclk,
-#endif
-#endif
-                in port p_mclk_in, clock clk_audio_bclk, unsigned int divide, unsigned curSamFreq);
-#else
 
 void ConfigAudioPortsWrapper(
 #if (I2S_CHANS_DAC != 0) || (DSD_CHANS_DAC != 0)
-                port p_i2s_dac[], int numPortsDAC,
+    out_buffered_port_32_t p_i2s_dac[],
+    int numPortsDAC,
 #endif
-
 #if (I2S_CHANS_ADC != 0)
-                port p_i2s_adc[], int numPortsADC,
+    in_buffered_port_32_t  p_i2s_adc[],
+    int numPortsADC,
 #endif
-
 #if (I2S_CHANS_DAC != 0) || (I2S_CHANS_ADC != 0)
-                port p_lrclk,
-                port p_bclk,
+#if (CODEC_MASTER == 0)
+    NULLABLE_RESOURCE(out_buffered_port_32_t, p_lrclk),
+    out_buffered_port_32_t p_bclk,
+#else
+    NULLABLE_RESOURCE(in_buffered_port_32_t, p_lrclk),
+    in_buffered_port_32_t p_bclk,
 #endif
-                port p_mclk_in, clock clk_audio_bclk, unsigned int divide, unsigned curSamFreq);
-
-
-#endif /* __XC__*/
+#endif
+    NULLABLE_RESOURCE(in_port_t,  p_mclk_in),
+    clock clk_audio_bclk, unsigned int divide, unsigned curSamFreq);
 
 #ifdef __XC__
 void EnableBufferedPort(buffered out port:32 p, unsigned transferWidth);

--- a/tests/xua_sim_tests/test_i2s_loopback/src/main.xc
+++ b/tests/xua_sim_tests/test_i2s_loopback/src/main.xc
@@ -5,6 +5,7 @@
 #include <print.h>
 #include <timer.h>
 #include "xua.h"
+#include "xua_commands.h" // Internal header, not part of lib_xua user API
 
 #define DEBUG_UNIT MAIN
 #include "debug_print.h"
@@ -70,14 +71,14 @@ on tile[AUDIO_IO_TILE] : buffered in port:32 p_i2s_adc[I2S_WIRES_ADC] =
 
 
 #if CODEC_MASTER
-buffered in port:32 p_lrclk       = PORT_I2S_LRCLK;
-buffered in port:32 p_bclk        = PORT_I2S_BCLK;
+buffered in port:32 p_lrclk         = PORT_I2S_LRCLK;
+buffered in port:32 p_bclk          = PORT_I2S_BCLK;
+#define p_mclk_in null
 #else
-buffered out port:32 p_lrclk       = PORT_I2S_LRCLK;    /* I2S Bit-clock */
-buffered out port:32 p_bclk        = PORT_I2S_BCLK;     /* I2S L/R-clock */
-#endif
-
+buffered out port:32 p_lrclk        = PORT_I2S_LRCLK;    /* I2S Bit-clock */
+buffered out port:32 p_bclk         = PORT_I2S_BCLK;     /* I2S L/R-clock */
 in port p_mclk_in                   = PORT_MCLK_IN;
+#endif
 
 /* Clock-block declarations */
 clock clk_audio_bclk                = on tile[AUDIO_IO_TILE]: XS1_CLKBLK_1;   /* Bit clock */
@@ -98,12 +99,11 @@ clock clk_audio_mclk                = on tile[AUDIO_IO_TILE]: XS1_CLKBLK_2;   /*
 
 void generator(chanend c_checker, chanend c_out)
 {
-  unsigned frame_count;
+  unsigned frame_count = 0;
   int underflow_word;
-  int fail;
+  int fail = 1;
   int i;
-
-  frame_count = 0;
+  unsigned time;
 
   while (1) {
     underflow_word = inuint(c_out);
@@ -120,12 +120,23 @@ void generator(chanend c_checker, chanend c_out)
       outuint(c_checker, inuint(c_out));
     }
 
+
     if (frame_count == TOTAL_TEST_FRAMES) {
       if (!fail) {
         debug_printf("PASS\n");
       }
-      outct(c_out, AUDIO_STOP_FOR_DFU);
+      outct(c_out, SET_SAMPLE_FREQ);
       //inuint(c_out); //This causes the DFUhandler to be called with exceptiopn in slave mode so skip this - we are out of here anyhow
+
+    /* Give some time for AudioHub() to react to the command to stop accessing ports otherwise exit()
+     * will trap in the port destructors
+     * Note, this is a bit of a cludge since ideally program would completely shutdown, however, AudioHub
+     * has a while(1)
+     */
+      timer t;
+      t :> time;
+      t when timerafter(time + 1000) :> void;
+
       exit(0);
     }
 

--- a/tests/xua_sim_tests/test_i2s_loopback/src/simulation.xc
+++ b/tests/xua_sim_tests/test_i2s_loopback/src/simulation.xc
@@ -5,8 +5,6 @@
 #include <platform.h>
 #include <print.h>
 
-extern port p_mclk_in;
-
 extern port p_mclk25mhz;
 extern clock clk_mclk25mhz;
 


### PR DESCRIPTION
- No longer use a mclk port when it's not required. For instance if using I2S slave with USB disabled (CODEC_MASTER=1 and XUA_USB_EN=0)
- Move XC/C type handling from multiple places to one place (xua.h) 
- Fixed incorrect BCD_DEVICE_J (we need a test for this...)
- Re-ordered changelog to ADDED, CHANGED, FIXED, REMOVED

I had to patch up an issue in test_i2s_loopback where it could trap sometimes. 
