### PR TITLE
Fix issue when NUM_PDM_MICS > 0

### DIFF
--- a/lib_xua/src/core/main.xc
+++ b/lib_xua/src/core/main.xc
@@ -714,7 +714,7 @@ int main()
         /* PDM Mics running on a separate to AudioHub */
         on stdcore[PDM_TILE]:
         {
-             mic_array_task(c_mic_pcm);
+             mic_array_task(c_pdm_pcm);
         }
 #endif /*XUA_NUM_PDM_MICS > 0*/
     }


### PR DESCRIPTION
mic_array_task called with undeclared c_mic_pdm instead of c_pcm_pdm