### PR TITLE
Pin lib_xud to v2.4.0

### DIFF
--- a/lib_xua/lib_build_info.cmake
+++ b/lib_xua/lib_build_info.cmake
@@ -31,7 +31,7 @@ set(LIB_DEPENDENT_MODULES "lib_adat(2.0.1)"
                           "lib_sw_pll(develop)"
                           "lib_xassert(4.3.1)"
                           "lib_mic_array(5.5.0)"
-                          "lib_xud(develop)")
+                          "lib_xud(2.4.0)")
 
 set(LIB_COMPILER_FLAGS -O3 -DREF_CLK_FREQ=100 -fasm-linenum -fcomment-asm)
 


### PR DESCRIPTION
lib_xud (develop) has breaking API change. 

Not sure as to the reason why we are currently tracking develop - there might be a good one!