### PR TITLE
Rationalise USB Audio Class defines

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -40,7 +40,9 @@ UNRELEASED
     not streaming which stops I2S and provides additional user callback.
   * FIXED:     Guard on epTypeTableOut[] in main where incorrect EP type
     for audio out endpoint occurred if additional custom endpoints added.
-  * REMOVED: Support for iAP EA Native Transport endpoints
+  * REMOVED:   Support for iAP EA Native Transport endpoints
+  * CHANGED:   Functionality associated with AUDIO_CLASS_FALLBACK and
+    FULL_SPEED_AUDIO_2 moved to XUA_AUDIO_CLASS_FS and XUA_AUDIO_CLASS_HS
 
 5.0.0
 -----

--- a/doc/rst/api_defines.rst
+++ b/doc/rst/api_defines.rst
@@ -44,8 +44,9 @@ Audio Class
 -----------
 
 .. doxygendefine:: AUDIO_CLASS
-.. doxygendefine:: AUDIO_CLASS_FALLBACK
-.. doxygendefine:: FULL_SPEED_AUDIO_2
+.. doxygendefine:: XUA_AUDIO_CLASS_HS
+.. doxygendefine:: XUA_AUDIO_CLASS_FS
+
 
 Feature configuration
 ---------------------

--- a/doc/rst/opt_audio_class.rst
+++ b/doc/rst/opt_audio_class.rst
@@ -3,63 +3,100 @@
 USB Audio Class version
 =======================
 
-The codebase supports USB Audio Class versions 1.0 and 2.0.
+The codebase supports USB Audio Class (UAC) versions 1.0 and 2.0.
 
-USB Audio Class 2.0 offers many improvements over USB Audio Class 1.0, most notable is the complete
-support for high-speed operation.  This means that Audio Class devices are no longer limited to
-full-speed operation allowing greater channel counts, sample frequencies and sample bit-depths.
+UAC 2.0 offers many improvements over UAC 1.0, most notable is the complete support for high-speed
+(HS) operation.  This means that Audio Class devices are no longer limited to full-speed (FS)
+operation allowing greater channel counts, sample frequencies and sample bit-depths.
 Additional improvements, amongst others, include:
 
 - Added support for multiple clock domains, clock description and clock control
 
-- Extensive support for interrupts to inform the host about dynamic changes that occur to different entities such as Clocks etc
+- Extensive support for interrupts to inform the host about dynamic changes that occur to different
+  entities such as Clocks etc
 
-Driver Support
+Driver support
 --------------
 
 Audio Class 1.0
 ^^^^^^^^^^^^^^^
 
- - Audio Class 1.0 is fully supported in Apple macOS.
- - Audio Class 1.0 is fully supported in all modern Microsoft Windows operating systems (i.e. Windows XP and later).
+ - Supported in Apple macOS.
+ - Supported in all modern Microsoft Windows operating systems (i.e. Windows XP and later).
 
 Audio Class 2.0
 ^^^^^^^^^^^^^^^
 
- - Audio Class 2.0 is fully supported in Apple macOS since version 10.6.4.
- - Starting with Windows 10, release 1703, a USB Audio 2.0 driver is shipped with Windows.
+ - Supported in Apple macOS since version 10.6.4.
+ - Supported in Windows since version 10, release 1703.
 
-Third party Windows drivers are also available, however, documentation of these is beyond the scope of this document, please contact `XMOS` for further details.
+Third party Windows drivers are also available, however, documentation of these is beyond the scope
+of this document, please contact `XMOS` for further details.
 
-Audio Class 1.0 mode and fall-back
-----------------------------------
+Configuring Audio Class version
+-------------------------------
 
-The default for `XMOS` USB Audio applications is to run as a high-speed Audio Class 2.0
-device. However, some products may prefer to run in Audio Class 1.0 mode, this is normally to
-allow "driver-less" operation with older versions of Windows operating systems or some embedded hosts.
+Configuring the ``AUDIO_CLASS`` define to ``1`` or ``2`` will set the UAC version for the device
+to 1.0 or 2.0 respectively.
 
-.. note::
+The default value is ``2`` which causes the device to run as a HS UAC 2.0 device when connected to
+a HS host/hub and as a FS UAC 2.0 device when connected to a FS host/hub.
 
-    To ensure specification compliance, Audio Class 1.0 mode *always* operates at full-speed USB.
+Setting ``AUDIO_CLASS`` to ``1`` will cause the device to run as a FS Audio Class 1.0 device.
 
-The device will operate in full-speed Audio Class 1.0 mode if one of the following is true:
+.. warning::
 
--  The code is compiled for USB Audio Class 1.0 only.
+    To ensure specification compliance, Audio Class 1.0 mode is not supported at high-speed.
 
--  The code is compiled for USB Audio Class 2.0 and it is connected
-   to the host over a full speed link (and the Audio Class fall back is
-   enabled).
+Defines are also provided to allow a different UAC version for HS and FS:
 
-The options to control this behavior are detailed in :ref:`sec_api_defines`.
+- ``XUA_AUDIO_CLASS_HS``: UAC version to run at high-speed (0: Disabled, 2: Audio Class 2.0)
+- ``XUA_AUDIO_CLASS_FS``: UAC version to run at full-speed (0: Disabled, 1: Audio Class 1.0, 2: Audio Class 2.0)
 
-Due to bandwidth limitations of full-speed USB the following sample-frequency restrictions are also applied:
+.. warning::
 
--  Sample rate is limited to a maximum of 48kHz if both input and output are enabled.
+    Disabling Audio Class support or dynamically switching between Audio Class 1.0 and 2.0 based on
+    USB bus speed may lead to USB compliance issues.
 
+    The USB-IF views such behavior as a significant functional change, which may violate compliance
+    requirements. Devices are expected to maintain consistent functionality regardless of bus speed,
+    and altering the USB class or interface descriptors dynamically can result in unpredictable host
+    behavior and test failures during USB-IF certification.
+
+    Recommendation: Avoid switching USB Audio Class modes based on bus speed.
+
+Due to bandwidth limitations of FS USB the following restrictions are applied during FS
+operation for both UAC 1.0 and 2.0 modes:
+
+-  Sample rate is limited to a maximum of 48kHz if both input *and* output is enabled.
 -  Sample rate is limited to a maximum of 96kHz if only input *or* output is enabled.
+-  Channel count is limited to a maximum of 2 channels for both input and output paths.
 
+Audio Class 1.0 devices
+^^^^^^^^^^^^^^^^^^^^^^^
 
-Related Defines
+Some products may opt to operate in UAC 1.0 mode to enable driver-less compatibility
+with older Windows versions or certain embedded hosts. This mode was historically preferred for
+ensuring basic plug-and-play audio functionality without requiring custom drivers.
+
+However, the need for UAC 1.0 support is diminishing as UAC 2.0 becomes more widely
+supported across modern operating systems and embedded platforms. UAC 2.0 offers better
+performance, higher sample rates, and more robust feature support, and is now natively supported
+on Windows 10+, macOS, Linux, and many embedded systems.
+
+Recommendation: Where possible, default to UAC 2.0 for new designs unless specific host
+compatibility requirements mandate support for UAC 1.0.
+
+The device will operate in FS UAC 1.0 mode if one of the following is true:
+
+- The code is compiled for USB Audio Class 1.0 *only* i.e.
+  - ``AUDIO_CLASS`` is set to ``1`` *or*
+  - ``XUA_AUDIO_CLASS_HS`` is set to ``0`` and ``XUA_AUDIO_CLASS_FS`` is set to ``1``.
+- The code is compiled for UAC 2.0 at HS and UAC 1.0 at FS i.e. ``XUA_AUDIO_CLASS_HS``
+  is set to ``2`` and ``XUA_AUDIO_CLASS_FS`` is set to ``1`` and the device is connected to a host
+  via a full-speed link
+
+Related defines
 ---------------
 
 :numref:`opt_audio_class_defines` describes the defines that affect audio class selection:
@@ -75,12 +112,11 @@ Related Defines
      - Default
    * - ``AUDIO_CLASS``
      - Audio Class version (1 or 2)
-     - N/A (*must* be defined)
-   * - ``AUDIO_CLASS_FALLBACK``
-     - Enable audio class fallback functionality
-     - ``0`` (disabled)
-
-.. warning::
-
-    Enabling USB Audio Class fallback functionality may have USB Compliance implications
+     - ``2``
+   * - ``XUA_AUDIO_CLASS_HS``
+     - Audio Class version to run at high-speed (0: Disabled,  2 UAC 2.0)
+     - ``2``
+   * - ``XUA_AUDIO_CLASS_FS``
+     - Audio Class version to run at full-speed (0: Disabled, 1: UAC 1.0, 2: UAC 2.)
+     - ``2``
 

--- a/lib_xua/api/xua_conf_default.h
+++ b/lib_xua/api/xua_conf_default.h
@@ -304,47 +304,62 @@
  */
 
 /**
- * @brief USB Audio Class Version
+ * @brief Legacy USB Audio Class version
  *
  * Default: 2 (Audio Class version 2.0)
+ *
+ * Note: XUA_USB_AUDIO_CLASS_HS and XUA_USB_AUDIO_CLASS_FS are derived from this value.
+ * Setting these defines directly will override this value.
  */
 #ifndef AUDIO_CLASS
 #define AUDIO_CLASS              (2)
 #endif
 
-/**
- * @brief Enable/disable fall back to Audio Class 1.0 in USB Full-speed.
+/** @brief Audio class version to run at HS
  *
- * Default: Disabled
+ * Default: AUDIO_CLASS
+ *
+ * Note: Set to 0 for no operation at HS.
  */
-#ifndef AUDIO_CLASS_FALLBACK
-#define AUDIO_CLASS_FALLBACK     (0)
+#ifndef XUA_AUDIO_CLASS_HS
+
+#if (AUDIO_CLASS == 1)
+    #define XUA_AUDIO_CLASS_HS   (0)
+#else
+    #define XUA_AUDIO_CLASS_HS   AUDIO_CLASS
+#endif
 #endif
 
-/**
- * @brief Whether or not to run UAC2 in full-speed. When disabled device can either operate in
- *        UAC1 mode in full-speed (if AUDIO_CLASS_FALLBACK enabled) or return "null" descriptors.
+/** @brief Audio class version to run at FS
  *
- * Default: 1 (Enabled) when AUDIO_CLASS_FALLBACK disabled.
+ * Default: AUDIO_CLASS
+ *
+ * Note: Set to 0 for no operation at FS.
  */
-#if ((AUDIO_CLASS == 2) || __DOXYGEN__)
-    /* Whether to run in Audio Class 2.0 mode in USB Full-speed */
-    #if !defined(FULL_SPEED_AUDIO_2) && (AUDIO_CLASS_FALLBACK == 0)
-        #define FULL_SPEED_AUDIO_2    1     /* Default to falling back to UAC2 */
+#ifndef XUA_AUDIO_CLASS_FS
+#define XUA_AUDIO_CLASS_FS       AUDIO_CLASS
+#endif
+
+/* @brief Desired USB Bus Speed to run the device at.
+ *
+ * Default: High-speed for UAC2.0, Full-speed for UAC1.0
+ *
+ * Note: this is a desired speed - the host may not support high-speed (HS) and the device will
+ * then run in full-speed (FS) mode.
+ */
+#ifndef XUA_USB_BUS_SPEED
+  #if AUDIO_CLASS == 1
+    #define XUA_USB_BUS_SPEED    XUD_SPEED_FS
+  #else
+    #define XUA_USB_BUS_SPEED    XUD_SPEED_HS
+  #endif
+#else
+    #if (XUA_USB_BUS_SPEED != XUD_SPEED_HS) && (XUA_USB_BUS_SPEED != XUD_SPEED_FS)
+        #error XUA_USB_BUS_SPEED must be either XUD_SPEED_HS or XUD_SPEED_FS
     #endif
-#endif
-
-#if defined(FULL_SPEED_AUDIO_2) && (FULL_SPEED_AUDIO_2 == 0)
-#undef FULL_SPEED_AUDIO_2
-#endif
-
-/* Some checks on full-speed functionality */
-#if defined(FULL_SPEED_AUDIO_2) && (AUDIO_CLASS_FALLBACK)
-#error FULL_SPEED_AUDIO_2 and AUDIO_CLASS_FALLBACK enabled!
-#endif
-
-#if (AUDIO_CLASS == 1) && defined(FULL_SPEED_AUDIO_2)
-#error AUDIO_CLASS set to 1 and FULL_SPEED_AUDIO_2 enabled!
+    #if (XUA_USB_BUS_SPEED == XUD_SPEED_HS) && (AUDIO_CLASS == 1)
+        #error XUA_USB_BUS_SPEED set to HS but AUDIO_CLASS set to 1, this is an invalid configuration!
+    #endif
 #endif
 
 /*
@@ -693,11 +708,11 @@
 #endif
 
 /**
- * @brief USB Product ID (PID) for Audio Class 1.0 mode. Only required if AUDIO_CLASS == 1 or AUDIO_CLASS_FALLBACK is enabled.
+ * @brief USB Product ID (PID) for Audio Class 1.0 mode. Only required if XUA_AUDIO_CLASS_FS == 1.
  *
  * Default: 0x0003
  */
-#if (AUDIO_CLASS == 1) || (AUDIO_CLASS_FALLBACK) || defined(__DOXYGEN__)
+#if (XUA_AUDIO_CLASS_FS == 1) || defined(__DOXYGEN__)
 #ifndef PID_AUDIO_1
 #define PID_AUDIO_1              (0x0003)
 #endif

--- a/lib_xua/src/core/endpoint0/xua_ep0_descriptors.h
+++ b/lib_xua/src/core/endpoint0/xua_ep0_descriptors.h
@@ -81,7 +81,7 @@ typedef struct
     STR_TABLE_ENTRY(vendorStr);
     STR_TABLE_ENTRY(serialStr);
 
-#if (AUDIO_CLASS == 2)
+#if (XUA_AUDIO_CLASS_HS == 2) || (XUA_AUDIO_CLASS_FS == 2)
     /* Audio 2.0 Strings */
     STR_TABLE_ENTRY(productStr_Audio2);           /* Product string for Audio 2 */
     STR_TABLE_ENTRY(outputInterfaceStr_Audio2);   /* iInterface for streaming intefaces */
@@ -89,7 +89,7 @@ typedef struct
     STR_TABLE_ENTRY(usbInputTermStr_Audio2);      /* Users sees as output from host */
     STR_TABLE_ENTRY(usbOutputTermStr_Audio2);     /* User sees as input to host */
 #endif
-#if  (AUDIO_CLASS_FALLBACK) || (AUDIO_CLASS == 1)
+#if (XUA_AUDIO_CLASS_FS == 1)
     /* Audio 1.0 Strings */
     STR_TABLE_ENTRY(productStr_Audio1);           /* Product string for Audio 1 */
     STR_TABLE_ENTRY(outputInterfaceStr_Audio1);   /* iInterface for streaming intefaces */
@@ -97,7 +97,7 @@ typedef struct
     STR_TABLE_ENTRY(usbInputTermStr_Audio1);      /* Users sees as output from host */
     STR_TABLE_ENTRY(usbOutputTermStr_Audio1);     /* User sees as input to host */
 #endif
-#if (AUDIO_CLASS == 2)
+#if (XUA_AUDIO_CLASS_HS == 2) || (XUA_AUDIO_CLASS_FS == 2)
     STR_TABLE_ENTRY(clockSelectorStr);            /* iClockSel */
     STR_TABLE_ENTRY(internalClockSourceStr);      /* iClockSource for internal clock */
 #if XUA_SPDIF_RX_EN
@@ -350,21 +350,21 @@ StringDescTable_t g_strTable =
     .langID                      = "\x09\x04", /* US English */
     .vendorStr                   = XUA_VENDOR_EMPTY_STRING,
     .serialStr                   = XUA_SERIAL_EMPTY_STRING,
-#if (AUDIO_CLASS == 2)
+#if (XUA_AUDIO_CLASS_HS == 2) || (XUA_AUDIO_CLASS_FS == 2)
     .productStr_Audio2           = XUA_PRODUCT_EMPTY_STRING,
     .outputInterfaceStr_Audio2   = XUA_PRODUCT_EMPTY_STRING,
     .inputInterfaceStr_Audio2    = XUA_PRODUCT_EMPTY_STRING,
     .usbInputTermStr_Audio2      = XUA_PRODUCT_EMPTY_STRING,
     .usbOutputTermStr_Audio2     = XUA_PRODUCT_EMPTY_STRING,
 #endif
-#if (AUDIO_CLASS_FALLBACK) || (AUDIO_CLASS == 1)
+#if (XUA_AUDIO_CLASS_FS == 1)
     .productStr_Audio1           = XUA_PRODUCT_EMPTY_STRING,
     .outputInterfaceStr_Audio1   = XUA_PRODUCT_EMPTY_STRING,
     .inputInterfaceStr_Audio1    = XUA_PRODUCT_EMPTY_STRING,
     .usbInputTermStr_Audio1      = XUA_PRODUCT_EMPTY_STRING,
     .usbOutputTermStr_Audio1     = XUA_PRODUCT_EMPTY_STRING,
 #endif
-#if (AUDIO_CLASS == 2)
+#if (XUA_AUDIO_CLASS_HS == 2) || (XUA_AUDIO_CLASS_FS == 2)
     .clockSelectorStr            = XUA_CLOCK_SELECTOR_EMPTY_STRING,
     .internalClockSourceStr      = XUA_INTERNAL_CLOCK_SELECTOR_EMPTY_STRING,
 #if (XUA_SPDIF_RX_EN)
@@ -426,7 +426,7 @@ StringDescTable_t g_strTable =
 
 /***** Device Descriptors *****/
 
-#if (AUDIO_CLASS_FALLBACK) || (AUDIO_CLASS == 1)
+#if (XUA_AUDIO_CLASS_FS == 1)
 /* Device Descriptor for Audio Class 1.0 (Assumes Full-Speed) */
 USB_Descriptor_Device_t devDesc_Audio1 =
 {
@@ -451,7 +451,7 @@ USB_Descriptor_Device_t devDesc_Audio1 =
 };
 #endif
 
-#if (AUDIO_CLASS == 2)
+#if (XUA_AUDIO_CLASS_HS == 2) || (XUA_AUDIO_CLASS_FS == 2)
 USB_Descriptor_Device_t devDesc_Audio2 =
 {
     .bLength                        = sizeof(USB_Descriptor_Device_t),
@@ -515,7 +515,7 @@ unsigned char devQualDesc_Audio2[] =
     0x00                            /* 9  bReserved (must be zero) */
 };
 
-#if (AUDIO_CLASS_FALLBACK) || (AUDIO_CLASS == 1)
+#if (XUA_AUDIO_CLASS_FS == 1)
 /* Device Qualifier Descriptor for running at high-speed (matches audio 1.0 device descriptor) */
 unsigned char devQualDesc_Audio1[] =
 {
@@ -808,7 +808,7 @@ typedef struct
     0x10,                                 /* 7    bcdDFUVersion */ \
     0x01                                /* 7    bcdDFUVersion */
 
-#if (AUDIO_CLASS == 2)
+#if (XUA_AUDIO_CLASS_HS == 2) || (XUA_AUDIO_CLASS_FS == 2)
 USB_Config_Descriptor_Audio2_t cfgDesc_Audio2=
 {
     .Config =
@@ -2107,12 +2107,12 @@ USB_Config_Descriptor_Audio2_t cfgDesc_Audio2=
 #endif /* (AUDIO_CLASS == 2) */
 
 #if XUA_OR_STATIC_HID_ENABLED
-#if (AUDIO_CLASS ==1 )
+#if (XUA_AUDIO_CLASS_FS  == 1)
 unsigned char hidDescriptor[] =
 {
     #include "xua_hid_descriptor_contents.h"
 };
-#elif (AUDIO_CLASS == 2)
+#elif (XUA_AUDIO_CLASS_HS == 2) || (XUA_AUDIO_CLASS_FS == 2)
 unsigned char* hidDescriptor = (unsigned char*) &cfgDesc_Audio2.HID_Descriptor;
 #else
     #error "Unknown Audio Class"
@@ -2150,7 +2150,7 @@ unsigned char cfgDesc_Null[] =
 };
 
 
-#if (AUDIO_CLASS_FALLBACK) || (AUDIO_CLASS == 1)
+#if (XUA_AUDIO_CLASS_FS == 1)
 /* Configuration descriptor for Audio v1.0 */
 /* Note Audio 1.0 descriptors still a simple array so we need some extra defines regarding lengths.. */
 #if (NUM_USB_CHAN_IN > 0)
@@ -2909,6 +2909,6 @@ unsigned char cfgDesc_Audio1[] =
 #endif
 
 };
-#endif // (AUDIO_CLASS_FALLBACK) || (AUDIO_CLASS == 1)
+#endif // (XUA_AUDIO_CLASS_FS == 1)
 #endif
 #endif // _DEVICE_DESCRIPTORS_

--- a/lib_xua/src/core/endpoint0/xua_ep0_uacreqs.xc
+++ b/lib_xua/src/core/endpoint0/xua_ep0_uacreqs.xc
@@ -893,7 +893,7 @@ int AudioClassRequests_2(XUD_ep ep0_out, XUD_ep ep0_in, USB_SetupPacket_t &sp, c
                                 int currentFreq48 = 8000;   //MIN_FREQ_48;
                                 unsigned maxFreq = MAX_FREQ;
 
-#if defined (FULL_SPEED_AUDIO_2)
+#if (XUA_AUDIO_CLASS_FS == 2)
                                 unsigned usbSpeed;
                                 asm("ldw   %0, dp[g_curUsbSpeed]" : "=r" (usbSpeed) :);
 
@@ -1101,8 +1101,7 @@ int AudioClassRequests_2(XUD_ep ep0_out, XUD_ep ep0_in, USB_SetupPacket_t &sp, c
 
 }
 
-#if (AUDIO_CLASS_FALLBACK != 0) || (AUDIO_CLASS == 1)
-
+#if (XUA_AUDIO_CLASS_FS == 1)
 int AudioEndpointRequests_1(XUD_ep ep0_out, XUD_ep ep0_in, USB_SetupPacket_t &sp, chanend ?c_aud_ctl, chanend ?c_mix_ctl, chanend ?c_clk_ctl)
 {
     /* At this point we know:

--- a/lib_xua/src/core/main.xc
+++ b/lib_xua/src/core/main.xc
@@ -508,14 +508,11 @@ int main()
 #ifdef XUD_PRIORITY_HIGH
                 set_core_high_priority_on();
 #endif
-                /* Run UAC2.0 at high-speed, UAC1.0 at full-speed */
-                unsigned usbSpeed = (AUDIO_CLASS == 2) ? XUD_SPEED_HS : XUD_SPEED_FS;
-
                 unsigned xudPwrCfg = (XUA_POWERMODE == XUA_POWERMODE_SELF) ? XUD_PWR_SELF : XUD_PWR_BUS;
 
                 /* USB interface core */
                 XUD_Main(c_xud_out, ENDPOINT_COUNT_OUT, c_xud_in, ENDPOINT_COUNT_IN,
-                         c_sof, epTypeTableOut, epTypeTableIn, usbSpeed, xudPwrCfg);
+                         c_sof, epTypeTableOut, epTypeTableIn, XUA_USB_BUS_SPEED, xudPwrCfg);
             }
 
 #if (NUM_USB_CHAN_OUT > 0) || (NUM_USB_CHAN_IN > 0) || XUA_HID_ENABLED || defined(MIDI)

--- a/lib_xua/src/core/warnings.xc
+++ b/lib_xua/src/core/warnings.xc
@@ -47,7 +47,7 @@ Warnings relating to configuration defines located in this XC source file rather
 #warning BCD_DEVICE not defined. Using XMOS release version number
 #endif
 
-#if (AUDIO_CLASS == 1) || (AUDIO_CLASS_FALLBACK)
+#if (XUA_AUDIO_CLASS_FS == 1)
 #ifndef PID_AUDIO_1
 #warning PID_AUDIO_1 not defined. Using 0x0003
 #endif
@@ -59,10 +59,6 @@ Warnings relating to configuration defines located in this XC source file rather
 
 #ifndef AUDIO_CLASS
 #warning AUDIO_CLASS not defined, using 2
-#endif
-
-#ifndef AUDIO_CLASS_FALLBACK
-#warning AUDIO_CLASS_FALLBACK not defined, using 0 (i.e. disabled)
 #endif
 
 /* Sanity check on FS channel counts */


### PR DESCRIPTION
- Added XUA_USB_BUS_SPEED
- Replaced AUDIO_CLASS_FALLBACK and FULL_SPEED_AUDIO_2 with XUA_AUDIO_CLASS_HS and XUA_AUDIO_CLASS_FS

Note, the string table initialisation that was added in #126 was buggy in places.

Actually lots of #126 was buggy

- char* XUA_Endpoint0_getProductStr() is also bad 
- void XUA_Endpoint0_setProductId(unsigned short pid) implementation is bad
- unsigned short XUA_Endpoint0_getVendorId() implementation is bad
- .... 
Basically all the Set and Get functions Luciano added are not correct. I patched up what I could quickly do and commented on the rest. I believe these are used for voice products that are configured from flash.
