### PR TITLE
Fixed issue with incorrect UAC2 descriptors when operating at full-speed

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,45 +4,46 @@ lib_xua change log
 UNRELEASED
 ----------
 
+  * ADDED:     Enumeration of vendor specific control interface as WinUSB
+    compatible on Windows. Can be disabled by defining
+    ENUMERATE_CONTROL_INTF_AS_WINUSB to 0
+  * ADDED:     Optional user_main_declarations.h and user_main_cores.h headers
+    to allow insertion of declarations and tasks for extending main()
+  * ADDED:     XUA_LOW_POWER_NON_STREAMING define allowing low-power state when
+    not streaming which stops I2S and provides additional user callback
+  * ADDED:     Documentation of XUA_CHAN_BUFF_CTRL
   * CHANGED:   Made `p_off_mclk` nullable for XUA_Buffer; this port is now only
     required either in configurations using Synchronous mode and using the
     application PLL to clock the USB buffers, or for configurations using
-    Asynchronous mode and using the reference clock to clock the USB buffers.
-  * FIXED:     `p_mclk_in` and `clk_audio_bclk` now correctly nullable when I2S
-    not in use.
-  * FIXED:     Corrected `clk_audio_mclk` nullability for XUA_AudioHub; this
-    clock block is only required for configurations with ADAT or SPDIF TX
-  * FIXED: Compilation error with NUM_USB_CHAN_IN=0, NUM_USB_CHAN_OUT=0 and
-    HID_CONTROLS=1 config
-  * FIXED: HID functionality with AUDIO_CLASS = 1
-  * FIXED: Alignment issue with HID_Descriptor memory that was causing
-    USB_GET_DESCRIPTOR for the HID interface to fail leading to failing USB3CV
-    HID Descriptor test
-  * ADDED: Support for setting wMaxPacketSize for MIDI bulk IN and OUT endpoints
-    at run time depending on g_curUsbSpeed
-  * ADDED:     Documented use of XUA_CHAN_BUFF_CTRL to save power
-  * CHANGED: Renamed USB_CONTROL_DESCS define to XUA_USB_CONTROL_DESCS
-  * FIXED: Device enumeration error when both XUA_DFU_EN and XUA_USB_CONTROL_DESCS
-    are enabled
-  * ADDED: Enumerate with vendor specific control interface as WinUSB compatible
-    on Windows. Can be disabled by defining ENUMERATE_CONTROL_INTF_AS_WINUSB to
-    0
-  * ADDED: HW test for vendor specific control interface
-  * FIXED:     Compiler error when PDM mics used and EXCLUDE_USB_AUDIO_MAIN is
-    not defined.
-  * CHANGED:   AN00248 updated so that it uses lib_xua main instead of own main
-    function.
-  * ADDED:     Optional user_main_declarations.h user_main_cores.h headers to
-    allow insertion of declarations and tasks for extending main.xc
-  * CHANGED: UserAudioStreamXxxx replaced by single UserAudioStreamState(in, out)
-    API with arguments indicating whether input or output streams are active
-  * ADDED: XUA_LOW_POWER_NON_STREAMING define allowing low-power state when
-    not streaming which stops I2S and provides additional user callback.
-  * FIXED:     Guard on epTypeTableOut[] in main where incorrect EP type
-    for audio out endpoint occurred if additional custom endpoints added.
-  * REMOVED:   Support for iAP EA Native Transport endpoints
+    Asynchronous mode and using the reference clock to clock the USB buffers
+  * CHANGED:   Renamed USB_CONTROL_DESCS define to XUA_USB_CONTROL_DESCS
+  * CHANGED:   AN00248 updated so that it uses lib_xua main() instead of custom
+    main()
+  * CHANGED:   UserAudioStreamStart and UserAudioStreamStop replaced by single
+    UserAudioStreamState(in, out) API with arguments indicating whether input
+    or output streams are active
   * CHANGED:   Functionality associated with AUDIO_CLASS_FALLBACK and
     FULL_SPEED_AUDIO_2 moved to XUA_AUDIO_CLASS_FS and XUA_AUDIO_CLASS_HS
+  * FIXED:      wMaxPacketSize for MIDI bulk IN and OUT endpoints incorrectly
+    set when running at full-speed
+  * FIXED:     `p_mclk_in` and `clk_audio_bclk` not correctly nullable when I2S
+    not in use.
+  * FIXED:     Incorrect `clk_audio_mclk` nullability for XUA_AudioHub; this
+    clock block is only required for configurations with ADAT or SPDIF TX
+  * FIXED:     Compilation error with NUM_USB_CHAN_IN=0, NUM_USB_CHAN_OUT=0 and
+    HID_CONTROLS=1
+  * FIXED:     HID functionality with AUDIO_CLASS = 1
+  * FIXED:     Alignment issue with HID_Descriptor memory that was causing
+    USB_GET_DESCRIPTOR for the HID interface to fail leading to failing USB3CV
+    HID Descriptor test
+  * FIXED:     Device enumeration error when both XUA_DFU_EN and
+    XUA_USB_CONTROL_DESCS enabled
+  * FIXED:     UAC2 descriptors during full-speed operation
+  * FIXED:     Compiler error when PDM mics used and EXCLUDE_USB_AUDIO_MAIN is
+    not defined.
+  * FIXED:     Guard on epTypeTableOut[] declaration where incorrect EP type
+    for audio out endpoint occurred if additional custom endpoints are added
+  * REMOVED:   Support for iAP EA Native Transport endpoints
 
 5.0.0
 -----

--- a/lib_xua/api/xua_conf_default.h
+++ b/lib_xua/api/xua_conf_default.h
@@ -349,12 +349,14 @@
  */
 #ifndef XUA_USB_BUS_SPEED
   #if AUDIO_CLASS == 1
+    /* XUD_SPEED_FS = 1 */
     #define XUA_USB_BUS_SPEED    XUD_SPEED_FS
   #else
+    /* XUD_SPEED_HS = 2 */
     #define XUA_USB_BUS_SPEED    XUD_SPEED_HS
   #endif
 #else
-    #if (XUA_USB_BUS_SPEED != XUD_SPEED_HS) && (XUA_USB_BUS_SPEED != XUD_SPEED_FS)
+    #if (XUA_USB_BUS_SPEED != 1) && (XUA_USB_BUS_SPEED != 2)
         #error XUA_USB_BUS_SPEED must be either XUD_SPEED_HS or XUD_SPEED_FS
     #endif
     #if (XUA_USB_BUS_SPEED == XUD_SPEED_HS) && (AUDIO_CLASS == 1)

--- a/lib_xua/src/core/buffer/decouple/decouple.xc
+++ b/lib_xua/src/core/buffer/decouple/decouple.xc
@@ -79,7 +79,7 @@ unsafe
 #endif
 
 /* Default to something sensible but the following are setup at stream start (unless UAC1 only..) */
-#if (AUDIO_CLASS == 2)
+#if (XUA_USB_BUS_SPEED == 2)
 int g_numUsbChan_In = NUM_USB_CHAN_IN; /* Number of channels to/from the USB bus - initialised to HS for UAC2.0 */
 int g_numUsbChan_Out = NUM_USB_CHAN_OUT;
 int g_curSubSlot_Out = HS_STREAM_FORMAT_OUTPUT_1_SUBSLOT_BYTES;
@@ -707,7 +707,7 @@ static void check_and_signal_stream_event_to_audio(chanend c_mix_out, unsigned d
             outct(c_mix_out, XUA_AUD_SET_AUDIO_START);
             outuint(c_mix_out, dsdMode);
             outuint(c_mix_out, sampResOut);
-        }            
+        }
         else
         {
             outct(c_mix_out, XUA_AUD_SET_AUDIO_STOP);

--- a/lib_xua/src/core/buffer/ep/ep_buffer.xc
+++ b/lib_xua/src/core/buffer/ep/ep_buffer.xc
@@ -33,7 +33,7 @@ extern unsigned int g_curSamFreqMultiplier;
 /* Initialise g_speed now so we get a sensible packet size until we start properly calculating feedback in the SoF case */
 /* Without this, zero size input packets fill the input FIFO and it takes a long time to clear out when feedback starts */
 /* This can cause a delay to the decouple ISR being serviced pushing our I2S timing. Initialising solves this */
-unsigned g_speed = (AUDIO_CLASS == 2) ? (DEFAULT_FREQ/8000) << 16 : (DEFAULT_FREQ/1000) << 16;
+unsigned g_speed = (XUA_USB_BUS_SPEED == 2) ? (DEFAULT_FREQ/8000) << 16 : (DEFAULT_FREQ/1000) << 16;
 unsigned g_streamChangeOngoing = 0; /* Not cleared until audio has completed it's SR change. This can be used for logic that needs to know audio has completed the command */
 unsigned g_feedbackValid = 0;
 

--- a/lib_xua/src/core/endpoint0/xua_endpoint0.c
+++ b/lib_xua/src/core/endpoint0/xua_endpoint0.c
@@ -127,7 +127,7 @@ XUD_BusSpeed_t g_curUsbSpeed = XUA_USB_BUS_SPEED;
 
 /* Global variables for current USB Vendor and Product strings */
 char g_vendor_str[XUA_MAX_STR_LEN] = VENDOR_STR;
-#if ((XUA_AUDIO_CLASS_HS == 2) && (XUA_USB_BUS_SPEED == XUD_SPEED_HS)) || ((XUA_AUDIO_CLASS_FS == 2) && (XUA_USB_BUS_SPEED == XUD_SPEED_FS))
+#if ((XUA_AUDIO_CLASS_HS == 2) && (XUA_USB_BUS_SPEED == 2)) || ((XUA_AUDIO_CLASS_FS == 2) && (XUA_USB_BUS_SPEED == 1))
 char g_product_str[XUA_MAX_STR_LEN] = PRODUCT_STR_A2;
 #else
 char g_product_str[XUA_MAX_STR_LEN] = PRODUCT_STR_A1;
@@ -1092,21 +1092,37 @@ void XUA_Endpoint0_loop(XUD_Result_t result, USB_SetupPacket_t sp, chanend c_ep0
                 cfgDesc_Audio2.Audio_Out_Format.bBitResolution = HS_STREAM_FORMAT_OUTPUT_1_RESOLUTION_BITS;
                 cfgDesc_Audio2.Audio_Out_Endpoint.wMaxPacketSize = HS_STREAM_FORMAT_OUTPUT_1_MAXPACKETSIZE;
                 cfgDesc_Audio2.Audio_Out_ClassStreamInterface.bNrChannels = HS_STREAM_FORMAT_OUTPUT_1_CHAN_COUNT;
+#if (NUM_USB_CHAN_IN == 0) || defined(UAC_FORCE_FEEDBACK_EP) && (XUA_SYNCMODE == XUA_SYNCMODE_ASYNC)
+                /* Async feedback endpoint descriptor change between FS and HS */
+                cfgDesc_Audio2.Audio_Out_Fb_Endpoint.wMaxPacketSize = FEEDBACK_MAX_PACKET_SIZE_HS;
+                cfgDesc_Audio2.Audio_Out_Fb_Endpoint.bInterval = FEEDBACK_INTERVAL_HS;
 #endif
+#endif // (NUM_USB_CHAN_OUT > 0)
 #if (OUTPUT_FORMAT_COUNT > 1)
                 cfgDesc_Audio2.Audio_Out_Format_2.bSubslotSize = HS_STREAM_FORMAT_OUTPUT_2_SUBSLOT_BYTES;
                 cfgDesc_Audio2.Audio_Out_Format_2.bBitResolution = HS_STREAM_FORMAT_OUTPUT_2_RESOLUTION_BITS;
                 cfgDesc_Audio2.Audio_Out_Endpoint_2.wMaxPacketSize = HS_STREAM_FORMAT_OUTPUT_2_MAXPACKETSIZE;
                 cfgDesc_Audio2.Audio_Out_ClassStreamInterface_2.bNrChannels = HS_STREAM_FORMAT_OUTPUT_2_CHAN_COUNT;
+#if (NUM_USB_CHAN_IN == 0) || defined(UAC_FORCE_FEEDBACK_EP) && (XUA_SYNCMODE == XUA_SYNCMODE_ASYNC)
+                /* Async feedback endpoint descriptor change between FS and HS */
+                cfgDesc_Audio2.Audio_Out_Fb_Endpoint_2.wMaxPacketSize = FEEDBACK_MAX_PACKET_SIZE_HS;
+                cfgDesc_Audio2.Audio_Out_Fb_Endpoint_2.bInterval = FEEDBACK_INTERVAL_HS;
 #endif
-
+#endif // (OUTPUT_FORMAT_COUNT > 1)
 #if (OUTPUT_FORMAT_COUNT > 2)
                 cfgDesc_Audio2.Audio_Out_Format_3.bSubslotSize = HS_STREAM_FORMAT_OUTPUT_3_SUBSLOT_BYTES;
                 cfgDesc_Audio2.Audio_Out_Format_3.bBitResolution = HS_STREAM_FORMAT_OUTPUT_3_RESOLUTION_BITS;
                 cfgDesc_Audio2.Audio_Out_Endpoint_3.wMaxPacketSize = HS_STREAM_FORMAT_OUTPUT_3_MAXPACKETSIZE;
                 cfgDesc_Audio2.Audio_Out_ClassStreamInterface_3.bNrChannels = HS_STREAM_FORMAT_OUTPUT_3_CHAN_COUNT;
+                cfgDesc_Audio2.Audio_Out_Fb_Endpoint_3.wMaxPacketSize = FEEDBACK_MAX_PACKET_SIZE_HS;
+#if (NUM_USB_CHAN_IN == 0) || defined(UAC_FORCE_FEEDBACK_EP) && (XUA_SYNCMODE == XUA_SYNCMODE_ASYNC)
+                /* Async feedback endpoint descriptor change between FS and HS */
+                cfgDesc_Audio2.Audio_Out_Fb_Endpoint.wMaxPacketSize = FEEDBACK_MAX_PACKET_SIZE_HS;
+                cfgDesc_Audio2.Audio_Out_Fb_Endpoint_3.bInterval = FEEDBACK_INTERVAL_HS;
 #endif
-#endif
+#endif // (OUTPUT_FORMAT_COUNT > 2)
+#endif // (NUM_USB_CHAN_OUT > 0)
+
 #if (NUM_USB_CHAN_IN > 0)
                 cfgDesc_Audio2.Audio_CS_Control_Int.Audio_In_InputTerminal.bNrChannels = NUM_USB_CHAN_IN;
                 cfgDesc_Audio2.Audio_In_Format.bSubslotSize = HS_STREAM_FORMAT_INPUT_1_SUBSLOT_BYTES;
@@ -1115,6 +1131,7 @@ void XUA_Endpoint0_loop(XUD_Result_t result, USB_SetupPacket_t sp, chanend c_ep0
                 cfgDesc_Audio2.Audio_In_ClassStreamInterface.bNrChannels = NUM_USB_CHAN_IN;
 #endif
 #if MIDI
+                /* MIDI endpoint max packet size must be 512 in HS */
                 cfgDesc_Audio2.MIDI_Descriptors.MIDI_Standard_Bulk_OUT_Endpoint.wMaxPacketSize = 512;
                 cfgDesc_Audio2.MIDI_Descriptors.MIDI_Standard_Bulk_IN_Endpoint.wMaxPacketSize = 512;
 #endif
@@ -1129,21 +1146,36 @@ void XUA_Endpoint0_loop(XUD_Result_t result, USB_SetupPacket_t sp, chanend c_ep0
                 cfgDesc_Audio2.Audio_Out_Format.bBitResolution = FS_STREAM_FORMAT_OUTPUT_1_RESOLUTION_BITS;
                 cfgDesc_Audio2.Audio_Out_Endpoint.wMaxPacketSize = FS_STREAM_FORMAT_OUTPUT_1_MAXPACKETSIZE;
                 cfgDesc_Audio2.Audio_Out_ClassStreamInterface.bNrChannels = NUM_USB_CHAN_OUT_FS;
+#if (NUM_USB_CHAN_IN == 0) || defined(UAC_FORCE_FEEDBACK_EP) && (XUA_SYNCMODE == XUA_SYNCMODE_ASYNC)
+                /* Async feedback endpoint descriptor change between FS and HS */
+                cfgDesc_Audio2.Audio_Out_Fb_Endpoint.wMaxPacketSize = FEEDBACK_MAX_PACKET_SIZE_FS;
+                cfgDesc_Audio2.Audio_Out_Fb_Endpoint.bInterval = FEEDBACK_INTERVAL_FS;
 #endif
+#endif // (NUM_USB_CHAN_OUT > 0)
 #if (OUTPUT_FORMAT_COUNT > 1)
                 cfgDesc_Audio2.Audio_Out_Format_2.bSubslotSize = FS_STREAM_FORMAT_OUTPUT_2_SUBSLOT_BYTES;
                 cfgDesc_Audio2.Audio_Out_Format_2.bBitResolution = FS_STREAM_FORMAT_OUTPUT_2_RESOLUTION_BITS;
                 cfgDesc_Audio2.Audio_Out_Endpoint_2.wMaxPacketSize = FS_STREAM_FORMAT_OUTPUT_2_MAXPACKETSIZE;
                 cfgDesc_Audio2.Audio_Out_ClassStreamInterface_2.bNrChannels = NUM_USB_CHAN_OUT_FS;
+#if (NUM_USB_CHAN_IN == 0) || defined(UAC_FORCE_FEEDBACK_EP) && (XUA_SYNCMODE == XUA_SYNCMODE_ASYNC)
+                /* Async feedback endpoint descriptor change between FS and HS */
+                cfgDesc_Audio2.Audio_Out_Fb_Endpoint_2.wMaxPacketSize = FEEDBACK_MAX_PACKET_SIZE_FS;
+                cfgDesc_Audio2.Audio_Out_Fb_Endpoint_2.bInterval = FEEDBACK_INTERVAL_FS;
+#endif // (OUTPUT_FORMAT_COUNT > 1)
 #endif
-
 #if (OUTPUT_FORMAT_COUNT > 2)
                 cfgDesc_Audio2.Audio_Out_Format_3.bSubslotSize = FS_STREAM_FORMAT_OUTPUT_3_SUBSLOT_BYTES;
                 cfgDesc_Audio2.Audio_Out_Format_3.bBitResolution = FS_STREAM_FORMAT_OUTPUT_3_RESOLUTION_BITS;
                 cfgDesc_Audio2.Audio_Out_Endpoint_3.wMaxPacketSize = FS_STREAM_FORMAT_OUTPUT_3_MAXPACKETSIZE;
                 cfgDesc_Audio2.Audio_Out_ClassStreamInterface_3.bNrChannels = NUM_USB_CHAN_OUT_FS;
+#if (NUM_USB_CHAN_IN == 0) || defined(UAC_FORCE_FEEDBACK_EP) && (XUA_SYNCMODE == XUA_SYNCMODE_ASYNC)
+                /* Async feedback endpoint descriptor change between FS and HS */
+                cfgDesc_Audio2.Audio_Out_Fb_Endpoint_3.wMaxPacketSize = FEEDBACK_MAX_PACKET_SIZE_FS;
+                cfgDesc_Audio2.Audio_Out_Fb_Endpoint_3.bInterval = FEEDBACK_INTERVAL_FS;
 #endif
-#endif
+#endif // (OUTPUT_FORMAT_COUNT > 2)
+#endif // (NUM_USB_CHAN_OUT > 0)
+
 #if (NUM_USB_CHAN_IN > 0)
                 cfgDesc_Audio2.Audio_CS_Control_Int.Audio_In_InputTerminal.bNrChannels = NUM_USB_CHAN_IN_FS;
                 cfgDesc_Audio2.Audio_In_Format.bSubslotSize = FS_STREAM_FORMAT_INPUT_1_SUBSLOT_BYTES;
@@ -1152,6 +1184,7 @@ void XUA_Endpoint0_loop(XUD_Result_t result, USB_SetupPacket_t sp, chanend c_ep0
                 cfgDesc_Audio2.Audio_In_ClassStreamInterface.bNrChannels = NUM_USB_CHAN_IN_FS;
 #endif
 #if MIDI
+                /* MIDI endpoint max packet size must be 64 bytes in FS */
                 cfgDesc_Audio2.MIDI_Descriptors.MIDI_Standard_Bulk_OUT_Endpoint.wMaxPacketSize = 64;
                 cfgDesc_Audio2.MIDI_Descriptors.MIDI_Standard_Bulk_IN_Endpoint.wMaxPacketSize = 64;
 #endif
@@ -1186,7 +1219,6 @@ void XUA_Endpoint0_loop(XUD_Result_t result, USB_SetupPacket_t sp, chanend c_ep0
 #endif
 #if XUA_DFU_EN
         }
-
         else
         {
             /* Running in DFU mode - always return same descs for DFU whether HS or FS */

--- a/lib_xua/src/core/endpoint0/xua_ep0_descriptors.h
+++ b/lib_xua/src/core/endpoint0/xua_ep0_descriptors.h
@@ -74,6 +74,11 @@
                                                     | (USB_ENDPOINT_SYNCTYPE_ADAPT << USB_ENDPOINT_SYNCTYPE_SHIFT)\
                                                     | (USB_ENDPOINT_USAGETYPE_IMPLICIT << USB_ENDPOINT_USAGETYPE_SHIFT))
 
+#define FEEDBACK_MAX_PACKET_SIZE_HS    (4)
+#define FEEDBACK_MAX_PACKET_SIZE_FS    (3)
+#define FEEDBACK_INTERVAL_HS           (4)         /* Only values <= 1 frame (4) supported by MS */
+#define FEEDBACK_INTERVAL_FS           (1)         /* Has to be 1 */
+
 #if __STDC__
 typedef struct
 {
@@ -1525,8 +1530,14 @@ USB_Config_Descriptor_Audio2_t cfgDesc_Audio2=
         .bDescriptorType    = USB_DESCTYPE_ENDPOINT,
         .bEndpointAddress   = ENDPOINT_ADDRESS_IN_FEEDBACK,
         .bmAttributes       = 17,         /* (bitmap) */
-        .wMaxPacketSize     = 0x0004,
-        .bInterval          = 4,          /* Only values <= 1 frame (4) supported by MS */
+        /* Note, this will be updated at run time based on the bus speed by endpoint 0 code */
+#if (XUA_USB_BUS_SPEED == 1)
+        .wMaxPacketSize     = FEEDBACK_MAX_PACKET_SIZE_FS,
+        .bInterval          = FEEDBACK_INTERVAL_FS,
+#else
+        .wMaxPacketSize     = FEEDBACK_MAX_PACKET_SIZE_HS,
+        .bInterval          = FEEDBACK_INTERVAL_HS,
+#endif
     },
 #endif
 #if (OUTPUT_FORMAT_COUNT > 1)
@@ -1611,12 +1622,18 @@ USB_Config_Descriptor_Audio2_t cfgDesc_Audio2=
 #if (NUM_USB_CHAN_IN == 0) || defined(UAC_FORCE_FEEDBACK_EP) && (XUA_SYNCMODE == XUA_SYNCMODE_ASYNC)
     .Audio_Out_Fb_Endpoint_2 =
     {
-        0x07,                             /* 0  bLength: 7 */
-        USB_DESCTYPE_ENDPOINT,            /* 1  bDescriptorType: ENDPOINT */
-        ENDPOINT_ADDRESS_IN_FEEDBACK,     /* 2  bEndpointAddress (D7: 0:out, 1:in) */
-        17,                               /* 3  bmAttributes (bitmap)  */
-        0x0004,                           /* 4  wMaxPacketSize */
-        4,                                /* 6  bInterval. Only values <= 1 frame (4) supported by MS */
+        .bLength                       = 0x07,
+        .bDescriptorType               = USB_DESCTYPE_ENDPOINT,
+        .bEndpointAddress              = ENDPOINT_ADDRESS_IN_FEEDBACK,
+        .bmAttributes                  = 17,                   /* (bitmap)  */
+        /* Note, this will be updated at run time based on the bus speed by endpoint 0 code */
+#if (XUA_USB_BUS_SPEED == 1)
+        .wMaxPacketSize                = FEEDBACK_MAX_PACKET_SIZE_FS,
+        .bInterval                     = FEEDBACK_INTERVAL_FS,
+#else
+        .wMaxPacketSize                = FEEDBACK_MAX_PACKET_SIZE_HS,
+        .bInterval                     = FEEDBACK_INTERVAL_HS,
+#endif
     },
 #endif
 #endif /* OUTPUT_FORMAT_COUNT > 1 */
@@ -1707,8 +1724,14 @@ USB_Config_Descriptor_Audio2_t cfgDesc_Audio2=
         .bDescriptorType               = USB_DESCTYPE_ENDPOINT,
         .bEndpointAddress              = ENDPOINT_ADDRESS_IN_FEEDBACK,
         .bmAttributes                  = 17,                   /* (bitmap)  */
-        .wMaxPacketSize                = 0x0004,
-        .bInterval                     = 4,                    /* Only values <= 1 frame (4) supported by MS */
+        /* Note, this will be updated at run time based on the bus speed by endpoint 0 code */
+#if (XUA_USB_BUS_SPEED == 1)
+        .wMaxPacketSize                = FEEDBACK_MAX_PACKET_SIZE_FS,
+        .bInterval                     = FEEDBACK_INTERVAL_FS,
+#else
+        .wMaxPacketSize                = FEEDBACK_MAX_PACKET_SIZE_HS,
+        .bInterval                     = FEEDBACK_INTERVAL_HS,
+#endif
     },
 #endif
 #endif /* OUTPUT_FORMAT_COUNT > 2 */


### PR DESCRIPTION
This is a long standing issue and could do with a test

The UAC2 descriptor were incorrect for FS operation - even for a static configuration. 

The feedback endpoint needs to have a different packet length and polling interval depending on if running at full or high speed.

This PR adds dynamic modification erroneous parts of UAC 2 descriptors based on bus-speed.

(Tidied change log in prep for release)