### PR TITLE
Various fixes to strings 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,45 +4,46 @@ lib_xua change log
 UNRELEASED
 ----------
 
+  * ADDED:     Enumeration of vendor specific control interface as WinUSB
+    compatible on Windows. Can be disabled by defining
+    ENUMERATE_CONTROL_INTF_AS_WINUSB to 0
+  * ADDED:     Optional user_main_declarations.h and user_main_cores.h headers
+    to allow insertion of declarations and tasks for extending main()
+  * ADDED:     XUA_LOW_POWER_NON_STREAMING define allowing low-power state when
+    not streaming which stops I2S and provides additional user callback
+  * ADDED:     Documentation of XUA_CHAN_BUFF_CTRL
   * CHANGED:   Made `p_off_mclk` nullable for XUA_Buffer; this port is now only
     required either in configurations using Synchronous mode and using the
     application PLL to clock the USB buffers, or for configurations using
-    Asynchronous mode and using the reference clock to clock the USB buffers.
-  * FIXED:     `p_mclk_in` and `clk_audio_bclk` now correctly nullable when I2S
-    not in use.
-  * FIXED:     Corrected `clk_audio_mclk` nullability for XUA_AudioHub; this
-    clock block is only required for configurations with ADAT or SPDIF TX
-  * FIXED: Compilation error with NUM_USB_CHAN_IN=0, NUM_USB_CHAN_OUT=0 and
-    HID_CONTROLS=1 config
-  * FIXED: HID functionality with AUDIO_CLASS = 1
-  * FIXED: Alignment issue with HID_Descriptor memory that was causing
-    USB_GET_DESCRIPTOR for the HID interface to fail leading to failing USB3CV
-    HID Descriptor test
-  * ADDED: Support for setting wMaxPacketSize for MIDI bulk IN and OUT endpoints
-    at run time depending on g_curUsbSpeed
-  * ADDED:     Documented use of XUA_CHAN_BUFF_CTRL to save power
-  * CHANGED: Renamed USB_CONTROL_DESCS define to XUA_USB_CONTROL_DESCS
-  * FIXED: Device enumeration error when both XUA_DFU_EN and XUA_USB_CONTROL_DESCS
-    are enabled
-  * ADDED: Enumerate with vendor specific control interface as WinUSB compatible
-    on Windows. Can be disabled by defining ENUMERATE_CONTROL_INTF_AS_WINUSB to
-    0
-  * ADDED: HW test for vendor specific control interface
-  * FIXED:     Compiler error when PDM mics used and EXCLUDE_USB_AUDIO_MAIN is
-    not defined.
-  * CHANGED:   AN00248 updated so that it uses lib_xua main instead of own main
-    function.
-  * ADDED:     Optional user_main_declarations.h user_main_cores.h headers to
-    allow insertion of declarations and tasks for extending main.xc
-  * CHANGED: UserAudioStreamXxxx replaced by single UserAudioStreamState(in, out)
-    API with arguments indicating whether input or output streams are active
-  * ADDED: XUA_LOW_POWER_NON_STREAMING define allowing low-power state when
-    not streaming which stops I2S and provides additional user callback.
-  * FIXED:     Guard on epTypeTableOut[] in main where incorrect EP type
-    for audio out endpoint occurred if additional custom endpoints added.
-  * REMOVED:   Support for iAP EA Native Transport endpoints
+    Asynchronous mode and using the reference clock to clock the USB buffers
+  * CHANGED:   Renamed USB_CONTROL_DESCS define to XUA_USB_CONTROL_DESCS
+  * CHANGED:   AN00248 updated so that it uses lib_xua main() instead of custom
+    main()
+  * CHANGED:   UserAudioStreamStart and UserAudioStreamStop replaced by single
+    UserAudioStreamState(in, out) API with arguments indicating whether input
+    or output streams are active
   * CHANGED:   Functionality associated with AUDIO_CLASS_FALLBACK and
     FULL_SPEED_AUDIO_2 moved to XUA_AUDIO_CLASS_FS and XUA_AUDIO_CLASS_HS
+  * FIXED:      wMaxPacketSize for MIDI bulk IN and OUT endpoints incorrectly
+    set when running at full-speed
+  * FIXED:     `p_mclk_in` and `clk_audio_bclk` not correctly nullable when I2S
+    not in use.
+  * FIXED:     Incorrect `clk_audio_mclk` nullability for XUA_AudioHub; this
+    clock block is only required for configurations with ADAT or SPDIF TX
+  * FIXED:     Compilation error with NUM_USB_CHAN_IN=0, NUM_USB_CHAN_OUT=0 and
+    HID_CONTROLS=1
+  * FIXED:     HID functionality with AUDIO_CLASS = 1
+  * FIXED:     Alignment issue with HID_Descriptor memory that was causing
+    USB_GET_DESCRIPTOR for the HID interface to fail leading to failing USB3CV
+    HID Descriptor test
+  * FIXED:     Device enumeration error when both XUA_DFU_EN and
+    XUA_USB_CONTROL_DESCS enabled
+  * FIXED:     UAC2 descriptors during full-speed operation
+  * FIXED:     Compiler error when PDM mics used and EXCLUDE_USB_AUDIO_MAIN is
+    not defined.
+  * FIXED:     Guard on epTypeTableOut[] declaration where incorrect EP type
+    for audio out endpoint occurred if additional custom endpoints are added
+  * REMOVED:   Support for iAP EA Native Transport endpoints
 
 5.0.0
 -----

--- a/lib_xua/api/xua_conf_default.h
+++ b/lib_xua/api/xua_conf_default.h
@@ -354,7 +354,7 @@
     #define XUA_USB_BUS_SPEED    XUD_SPEED_HS
   #endif
 #else
-    #if (XUA_USB_BUS_SPEED != XUD_SPEED_HS) && (XUA_USB_BUS_SPEED != XUD_SPEED_FS)
+    #if (XUA_USB_BUS_SPEED != 1) && (XUA_USB_BUS_SPEED != 2)
         #error XUA_USB_BUS_SPEED must be either XUD_SPEED_HS or XUD_SPEED_FS
     #endif
     #if (XUA_USB_BUS_SPEED == XUD_SPEED_HS) && (AUDIO_CLASS == 1)

--- a/lib_xua/src/core/buffer/decouple/decouple.xc
+++ b/lib_xua/src/core/buffer/decouple/decouple.xc
@@ -79,7 +79,7 @@ unsafe
 #endif
 
 /* Default to something sensible but the following are setup at stream start (unless UAC1 only..) */
-#if (AUDIO_CLASS == 2)
+#if (XUA_USB_BUS_SPEED == 2)
 int g_numUsbChan_In = NUM_USB_CHAN_IN; /* Number of channels to/from the USB bus - initialised to HS for UAC2.0 */
 int g_numUsbChan_Out = NUM_USB_CHAN_OUT;
 int g_curSubSlot_Out = HS_STREAM_FORMAT_OUTPUT_1_SUBSLOT_BYTES;
@@ -707,7 +707,7 @@ static void check_and_signal_stream_event_to_audio(chanend c_mix_out, unsigned d
             outct(c_mix_out, XUA_AUD_SET_AUDIO_START);
             outuint(c_mix_out, dsdMode);
             outuint(c_mix_out, sampResOut);
-        }            
+        }
         else
         {
             outct(c_mix_out, XUA_AUD_SET_AUDIO_STOP);

--- a/lib_xua/src/core/buffer/ep/ep_buffer.xc
+++ b/lib_xua/src/core/buffer/ep/ep_buffer.xc
@@ -33,7 +33,7 @@ extern unsigned int g_curSamFreqMultiplier;
 /* Initialise g_speed now so we get a sensible packet size until we start properly calculating feedback in the SoF case */
 /* Without this, zero size input packets fill the input FIFO and it takes a long time to clear out when feedback starts */
 /* This can cause a delay to the decouple ISR being serviced pushing our I2S timing. Initialising solves this */
-unsigned g_speed = (AUDIO_CLASS == 2) ? (DEFAULT_FREQ/8000) << 16 : (DEFAULT_FREQ/1000) << 16;
+unsigned g_speed = (XUA_USB_BUS_SPEED == 2) ? (DEFAULT_FREQ/8000) << 16 : (DEFAULT_FREQ/1000) << 16;
 unsigned g_streamChangeOngoing = 0; /* Not cleared until audio has completed it's SR change. This can be used for logic that needs to know audio has completed the command */
 unsigned g_feedbackValid = 0;
 

--- a/lib_xua/src/core/endpoint0/xua_endpoint0.c
+++ b/lib_xua/src/core/endpoint0/xua_endpoint0.c
@@ -127,7 +127,7 @@ XUD_BusSpeed_t g_curUsbSpeed = XUA_USB_BUS_SPEED;
 
 /* Global variables for current USB Vendor and Product strings */
 char g_vendor_str[XUA_MAX_STR_LEN] = VENDOR_STR;
-#if ((XUA_AUDIO_CLASS_HS == 2) && (XUA_USB_BUS_SPEED == XUD_SPEED_HS)) || ((XUA_AUDIO_CLASS_FS == 2) && (XUA_USB_BUS_SPEED == XUD_SPEED_FS))
+#if ((XUA_AUDIO_CLASS_HS == 2) && (XUA_USB_BUS_SPEED == 2)) || ((XUA_AUDIO_CLASS_FS == 2) && (XUA_USB_BUS_SPEED == 1))
 char g_product_str[XUA_MAX_STR_LEN] = PRODUCT_STR_A2;
 #else
 char g_product_str[XUA_MAX_STR_LEN] = PRODUCT_STR_A1;
@@ -1092,21 +1092,37 @@ void XUA_Endpoint0_loop(XUD_Result_t result, USB_SetupPacket_t sp, chanend c_ep0
                 cfgDesc_Audio2.Audio_Out_Format.bBitResolution = HS_STREAM_FORMAT_OUTPUT_1_RESOLUTION_BITS;
                 cfgDesc_Audio2.Audio_Out_Endpoint.wMaxPacketSize = HS_STREAM_FORMAT_OUTPUT_1_MAXPACKETSIZE;
                 cfgDesc_Audio2.Audio_Out_ClassStreamInterface.bNrChannels = HS_STREAM_FORMAT_OUTPUT_1_CHAN_COUNT;
+#if (NUM_USB_CHAN_IN == 0) || defined(UAC_FORCE_FEEDBACK_EP) && (XUA_SYNCMODE == XUA_SYNCMODE_ASYNC)
+                /* Async feedback endpoint descriptor change between FS and HS */
+                cfgDesc_Audio2.Audio_Out_Fb_Endpoint.wMaxPacketSize = FEEDBACK_MAX_PACKET_SIZE_HS;
+                cfgDesc_Audio2.Audio_Out_Fb_Endpoint.bInterval = FEEDBACK_INTERVAL_HS;
 #endif
+#endif // (NUM_USB_CHAN_OUT > 0)
 #if (OUTPUT_FORMAT_COUNT > 1)
                 cfgDesc_Audio2.Audio_Out_Format_2.bSubslotSize = HS_STREAM_FORMAT_OUTPUT_2_SUBSLOT_BYTES;
                 cfgDesc_Audio2.Audio_Out_Format_2.bBitResolution = HS_STREAM_FORMAT_OUTPUT_2_RESOLUTION_BITS;
                 cfgDesc_Audio2.Audio_Out_Endpoint_2.wMaxPacketSize = HS_STREAM_FORMAT_OUTPUT_2_MAXPACKETSIZE;
                 cfgDesc_Audio2.Audio_Out_ClassStreamInterface_2.bNrChannels = HS_STREAM_FORMAT_OUTPUT_2_CHAN_COUNT;
+#if (NUM_USB_CHAN_IN == 0) || defined(UAC_FORCE_FEEDBACK_EP) && (XUA_SYNCMODE == XUA_SYNCMODE_ASYNC)
+                /* Async feedback endpoint descriptor change between FS and HS */
+                cfgDesc_Audio2.Audio_Out_Fb_Endpoint_2.wMaxPacketSize = FEEDBACK_MAX_PACKET_SIZE_HS;
+                cfgDesc_Audio2.Audio_Out_Fb_Endpoint_2.bInterval = FEEDBACK_INTERVAL_HS;
 #endif
-
+#endif // (OUTPUT_FORMAT_COUNT > 1)
 #if (OUTPUT_FORMAT_COUNT > 2)
                 cfgDesc_Audio2.Audio_Out_Format_3.bSubslotSize = HS_STREAM_FORMAT_OUTPUT_3_SUBSLOT_BYTES;
                 cfgDesc_Audio2.Audio_Out_Format_3.bBitResolution = HS_STREAM_FORMAT_OUTPUT_3_RESOLUTION_BITS;
                 cfgDesc_Audio2.Audio_Out_Endpoint_3.wMaxPacketSize = HS_STREAM_FORMAT_OUTPUT_3_MAXPACKETSIZE;
                 cfgDesc_Audio2.Audio_Out_ClassStreamInterface_3.bNrChannels = HS_STREAM_FORMAT_OUTPUT_3_CHAN_COUNT;
+                cfgDesc_Audio2.Audio_Out_Fb_Endpoint_3.wMaxPacketSize = FEEDBACK_MAX_PACKET_SIZE_HS;
+#if (NUM_USB_CHAN_IN == 0) || defined(UAC_FORCE_FEEDBACK_EP) && (XUA_SYNCMODE == XUA_SYNCMODE_ASYNC)
+                /* Async feedback endpoint descriptor change between FS and HS */
+                cfgDesc_Audio2.Audio_Out_Fb_Endpoint.wMaxPacketSize = FEEDBACK_MAX_PACKET_SIZE_HS;
+                cfgDesc_Audio2.Audio_Out_Fb_Endpoint_3.bInterval = FEEDBACK_INTERVAL_HS;
 #endif
-#endif
+#endif // (OUTPUT_FORMAT_COUNT > 2)
+#endif // (NUM_USB_CHAN_OUT > 0)
+
 #if (NUM_USB_CHAN_IN > 0)
                 cfgDesc_Audio2.Audio_CS_Control_Int.Audio_In_InputTerminal.bNrChannels = NUM_USB_CHAN_IN;
                 cfgDesc_Audio2.Audio_In_Format.bSubslotSize = HS_STREAM_FORMAT_INPUT_1_SUBSLOT_BYTES;
@@ -1115,6 +1131,7 @@ void XUA_Endpoint0_loop(XUD_Result_t result, USB_SetupPacket_t sp, chanend c_ep0
                 cfgDesc_Audio2.Audio_In_ClassStreamInterface.bNrChannels = NUM_USB_CHAN_IN;
 #endif
 #if MIDI
+                /* MIDI endpoint max packet size must be 512 in HS */
                 cfgDesc_Audio2.MIDI_Descriptors.MIDI_Standard_Bulk_OUT_Endpoint.wMaxPacketSize = 512;
                 cfgDesc_Audio2.MIDI_Descriptors.MIDI_Standard_Bulk_IN_Endpoint.wMaxPacketSize = 512;
 #endif
@@ -1129,21 +1146,36 @@ void XUA_Endpoint0_loop(XUD_Result_t result, USB_SetupPacket_t sp, chanend c_ep0
                 cfgDesc_Audio2.Audio_Out_Format.bBitResolution = FS_STREAM_FORMAT_OUTPUT_1_RESOLUTION_BITS;
                 cfgDesc_Audio2.Audio_Out_Endpoint.wMaxPacketSize = FS_STREAM_FORMAT_OUTPUT_1_MAXPACKETSIZE;
                 cfgDesc_Audio2.Audio_Out_ClassStreamInterface.bNrChannels = NUM_USB_CHAN_OUT_FS;
+#if (NUM_USB_CHAN_IN == 0) || defined(UAC_FORCE_FEEDBACK_EP) && (XUA_SYNCMODE == XUA_SYNCMODE_ASYNC)
+                /* Async feedback endpoint descriptor change between FS and HS */
+                cfgDesc_Audio2.Audio_Out_Fb_Endpoint.wMaxPacketSize = FEEDBACK_MAX_PACKET_SIZE_FS;
+                cfgDesc_Audio2.Audio_Out_Fb_Endpoint.bInterval = FEEDBACK_INTERVAL_FS;
 #endif
+#endif // (NUM_USB_CHAN_OUT > 0)
 #if (OUTPUT_FORMAT_COUNT > 1)
                 cfgDesc_Audio2.Audio_Out_Format_2.bSubslotSize = FS_STREAM_FORMAT_OUTPUT_2_SUBSLOT_BYTES;
                 cfgDesc_Audio2.Audio_Out_Format_2.bBitResolution = FS_STREAM_FORMAT_OUTPUT_2_RESOLUTION_BITS;
                 cfgDesc_Audio2.Audio_Out_Endpoint_2.wMaxPacketSize = FS_STREAM_FORMAT_OUTPUT_2_MAXPACKETSIZE;
                 cfgDesc_Audio2.Audio_Out_ClassStreamInterface_2.bNrChannels = NUM_USB_CHAN_OUT_FS;
+#if (NUM_USB_CHAN_IN == 0) || defined(UAC_FORCE_FEEDBACK_EP) && (XUA_SYNCMODE == XUA_SYNCMODE_ASYNC)
+                /* Async feedback endpoint descriptor change between FS and HS */
+                cfgDesc_Audio2.Audio_Out_Fb_Endpoint_2.wMaxPacketSize = FEEDBACK_MAX_PACKET_SIZE_FS;
+                cfgDesc_Audio2.Audio_Out_Fb_Endpoint_2.bInterval = FEEDBACK_INTERVAL_FS;
+#endif // (OUTPUT_FORMAT_COUNT > 1)
 #endif
-
 #if (OUTPUT_FORMAT_COUNT > 2)
                 cfgDesc_Audio2.Audio_Out_Format_3.bSubslotSize = FS_STREAM_FORMAT_OUTPUT_3_SUBSLOT_BYTES;
                 cfgDesc_Audio2.Audio_Out_Format_3.bBitResolution = FS_STREAM_FORMAT_OUTPUT_3_RESOLUTION_BITS;
                 cfgDesc_Audio2.Audio_Out_Endpoint_3.wMaxPacketSize = FS_STREAM_FORMAT_OUTPUT_3_MAXPACKETSIZE;
                 cfgDesc_Audio2.Audio_Out_ClassStreamInterface_3.bNrChannels = NUM_USB_CHAN_OUT_FS;
+#if (NUM_USB_CHAN_IN == 0) || defined(UAC_FORCE_FEEDBACK_EP) && (XUA_SYNCMODE == XUA_SYNCMODE_ASYNC)
+                /* Async feedback endpoint descriptor change between FS and HS */
+                cfgDesc_Audio2.Audio_Out_Fb_Endpoint_3.wMaxPacketSize = FEEDBACK_MAX_PACKET_SIZE_FS;
+                cfgDesc_Audio2.Audio_Out_Fb_Endpoint_3.bInterval = FEEDBACK_INTERVAL_FS;
 #endif
-#endif
+#endif // (OUTPUT_FORMAT_COUNT > 2)
+#endif // (NUM_USB_CHAN_OUT > 0)
+
 #if (NUM_USB_CHAN_IN > 0)
                 cfgDesc_Audio2.Audio_CS_Control_Int.Audio_In_InputTerminal.bNrChannels = NUM_USB_CHAN_IN_FS;
                 cfgDesc_Audio2.Audio_In_Format.bSubslotSize = FS_STREAM_FORMAT_INPUT_1_SUBSLOT_BYTES;
@@ -1152,6 +1184,7 @@ void XUA_Endpoint0_loop(XUD_Result_t result, USB_SetupPacket_t sp, chanend c_ep0
                 cfgDesc_Audio2.Audio_In_ClassStreamInterface.bNrChannels = NUM_USB_CHAN_IN_FS;
 #endif
 #if MIDI
+                /* MIDI endpoint max packet size must be 64 bytes in FS */
                 cfgDesc_Audio2.MIDI_Descriptors.MIDI_Standard_Bulk_OUT_Endpoint.wMaxPacketSize = 64;
                 cfgDesc_Audio2.MIDI_Descriptors.MIDI_Standard_Bulk_IN_Endpoint.wMaxPacketSize = 64;
 #endif
@@ -1186,7 +1219,6 @@ void XUA_Endpoint0_loop(XUD_Result_t result, USB_SetupPacket_t sp, chanend c_ep0
 #endif
 #if XUA_DFU_EN
         }
-
         else
         {
             /* Running in DFU mode - always return same descs for DFU whether HS or FS */

--- a/lib_xua/src/core/endpoint0/xua_endpoint0.c
+++ b/lib_xua/src/core/endpoint0/xua_endpoint0.c
@@ -125,17 +125,6 @@ unsigned g_curStreamAlt_In = 0;
 /* Global variable for current USB bus speed (i.e. FS/HS) */
 XUD_BusSpeed_t g_curUsbSpeed = XUA_USB_BUS_SPEED;
 
-/* Global variables for current USB Vendor and Product strings */
-char g_vendor_str[XUA_MAX_STR_LEN] = VENDOR_STR;
-#if ((XUA_AUDIO_CLASS_HS == 2) && (XUA_USB_BUS_SPEED == 2)) || ((XUA_AUDIO_CLASS_FS == 2) && (XUA_USB_BUS_SPEED == 1))
-char g_product_str[XUA_MAX_STR_LEN] = PRODUCT_STR_A2;
-#else
-char g_product_str[XUA_MAX_STR_LEN] = PRODUCT_STR_A1;
-#endif
-
-/* Global variable for current USB Serial Number strings */
-char g_serial_str[XUA_MAX_STR_LEN] = SERIAL_STR;
-
 #if _XUA_ENABLE_BOS_DESC
 /* Device Interface GUID*/
 char g_device_interface_guid_dfu_str[DEVICE_INTERFACE_GUID_MAX_STRLEN+1] = WINUSB_DEVICE_INTERFACE_GUID_DFU;
@@ -309,84 +298,71 @@ void InitLocalMixerState()
 }
 #endif
 
-void concatenateAndCopyStrings(char* string1, char* string2, char* string_buffer) {
-    debug_printf("concatenateAndCopyStrings() for \"%s\" and \"%s\"\n", string1, string2);
+void concatenateAndCopyStrings(char* string1, char* string2, char* destBuffer, size_t destLen)
+{
+    printf("concatenateAndCopyStrings() for \"%s\" and \"%s\"\n", string1, string2);
 
-    memset(string_buffer, '\0', strlen(string_buffer));
+    memset(destBuffer, '\0', strlen(destBuffer));
 
-    uint32_t remaining_buffer_size = MIN(strlen(string1), XUA_MAX_STR_LEN-1);
-    strncpy(string_buffer, string1, remaining_buffer_size);
-    uint32_t total_string_size = MIN(strlen(string1)+strlen(string2), XUA_MAX_STR_LEN-1);
-    if (total_string_size==XUA_MAX_STR_LEN-1) {
-        remaining_buffer_size =  XUA_MAX_STR_LEN-1-strlen(string1);
-    } else {
-        remaining_buffer_size = strlen(string2);
-    }
+    /* Copy string1 into the destination buffer */
+    strncat(destBuffer, string1, destLen);
 
-    strncat(string_buffer, string2, remaining_buffer_size);
-    debug_printf("concatenateAndCopyStrings() creates \"%s\"\n", string_buffer);
+    /* Cat what we can of string2 onto the destination buffer */
+    strncat(destBuffer, string2, destLen - strlen(string1));
+
+    printf("concatenateAndCopyStrings() creates \"%s\"\n", destBuffer);
 }
 
-void XUA_Endpoint0_setStrTable() {
+void XUA_Endpoint0_setVendorStr(char* vendorStr)
+{
+    debug_printf("XUA_Endpoint0_setVendorStr() with string %s\n", vendorStr);
+    concatenateAndCopyStrings(vendorStr, "", g_strTable.vendorStr, sizeof(XUA_VENDOR_DEFAULT_STRING));
 
-    // update Vendor strings
-    concatenateAndCopyStrings(g_vendor_str, "", g_strTable.vendorStr);
+    /* Update other strings with the new vendorStr */
 #if (XUA_AUDIO_CLASS_HS == 2) || (XUA_AUDIO_CLASS_FS == 2)
-    concatenateAndCopyStrings(g_vendor_str, " Clock Selector", g_strTable.clockSelectorStr);
-    concatenateAndCopyStrings(g_vendor_str, " Internal Clock", g_strTable.internalClockSourceStr);
+    concatenateAndCopyStrings(vendorStr, " Clock Selector", g_strTable.clockSelectorStr, sizeof(XUA_CLOCK_SELECTOR_DEFAULT_STRING));
+    concatenateAndCopyStrings(vendorStr, " Internal Clock", g_strTable.internalClockSourceStr, sizeof(XUA_INTERNAL_CLOCK_SOURCE_DEFAULT_STRING));
 #endif
 #if (XUA_SPDIF_RX_EN)
-    concatenateAndCopyStrings(g_vendor_str, " S/PDIF Clock", g_strTable.spdifClockSourceStr);
+    concatenateAndCopyStrings(vendorStr, " S/PDIF Clock", g_strTable.spdifClockSourceStr, sizeof(XUA_SPDIF_CLOCK_SOURCE_DEFAULT_STRING));
 #endif
 #if (XUA_ADAT_RX_EN)
-    concatenateAndCopyStrings(g_vendor_str, " ADAT Clock", g_strTable.adatClockSourceStr);
+    concatenateAndCopyStrings(vendorStr, " ADAT Clock", g_strTable.adatClockSourceStr, sizeof(XUA_ADAT_CLOCK_SOURCE_DEFAULT_STRING));
 #endif
 #if XUA_DFU_EN
-    concatenateAndCopyStrings(g_vendor_str, " DFU", g_strTable.dfuStr);
+    concatenateAndCopyStrings(vendorStr, " DFU", g_strTable.dfuStr, sizeof(XUA_DFU_DEFAULT_STRING));
 #endif
 #if XUA_USB_CONTROL_DESCS
-    concatenateAndCopyStrings(g_vendor_str, " Control", g_strTable.ctrlStr);
+    concatenateAndCopyStrings(vendorStr, " Control", g_strTable.ctrlStr, sizeof(XUA_CONTROL_DEFAULT_STRING));
 #endif
 #ifdef MIDI
-    concatenateAndCopyStrings(g_vendor_str, " MIDI Out", g_strTable.midiOutStr);
-    concatenateAndCopyStrings(g_vendor_str, " MIDI In", g_strTable.midiInStr);
+    concatenateAndCopyStrings(vendorStr, " MIDI Out", g_strTable.midiOutStr, sizeof(XUA_MIDI_OUT_DEFAULT_STRING));
+    concatenateAndCopyStrings(vendorStr, " MIDI In", g_strTable.midiInStr, sizeof(XUA_MIDI_IN_DEFAULT_STRING));
 #endif
-    // update product strings
+}
+
+/* Note, this writes both UAC1 and UAC2 product strings */
+void XUA_Endpoint0_setProductStr(char* productStr)
+{
+    debug_printf("XUA_Endpoint0_setProductStr() with string %s\n", productStr);
+
 #if (XUA_AUDIO_CLASS_FS == 1)
-    concatenateAndCopyStrings(g_product_str, "", g_strTable.productStr_Audio1);
-    concatenateAndCopyStrings(g_product_str, "", g_strTable.outputInterfaceStr_Audio1);
-    concatenateAndCopyStrings(g_product_str, "", g_strTable.inputInterfaceStr_Audio1);
-    concatenateAndCopyStrings(g_product_str, "", g_strTable.usbInputTermStr_Audio1);
-    concatenateAndCopyStrings(g_product_str, "", g_strTable.usbOutputTermStr_Audio1);
+    concatenateAndCopyStrings(productStr, "", g_strTable.productStr_Audio1, sizeof(XUA_PRODUCT_A1_DEFAULT_STRING));
 #endif
 #if (XUA_AUDIO_CLASS_HS == 2) || (XUA_AUDIO_CLASS_FS == 2)
-    concatenateAndCopyStrings(g_product_str, "", g_strTable.productStr_Audio2);
-    concatenateAndCopyStrings(g_product_str, "", g_strTable.outputInterfaceStr_Audio2);
-    concatenateAndCopyStrings(g_product_str, "", g_strTable.inputInterfaceStr_Audio2);
-    concatenateAndCopyStrings(g_product_str, "", g_strTable.usbInputTermStr_Audio2);
-    concatenateAndCopyStrings(g_product_str, "", g_strTable.usbOutputTermStr_Audio2);
+    concatenateAndCopyStrings(productStr, "", g_strTable.productStr_Audio2, sizeof(XUA_PRODUCT_A2_DEFAULT_STRING));
 #endif
-
-    // update Serial strings
-    concatenateAndCopyStrings(g_serial_str, "", g_strTable.serialStr);
+    /* Note, don't update outputInterfaceStr_Audio2, inputInterfaceStr_Audio2 etc as they are all pointing to the same string */
 }
 
-void XUA_Endpoint0_setVendorStr(char* vendor_str) {
-    debug_printf("XUA_Endpoint0_setVendorStr() with string %s\n", vendor_str);
-    concatenateAndCopyStrings(vendor_str, "", g_vendor_str);
+void XUA_Endpoint0_setSerialStr(char* serialStr)
+{
+    debug_printf("XUA_Endpoint0_setSerialStr() with string %s\n", serialStr);
+    concatenateAndCopyStrings(serialStr, "", g_strTable.serialStr, sizeof(XUA_SERIAL_DEFAULT_STRING));
 }
 
-void XUA_Endpoint0_setProductStr(char* product_str) {
-    debug_printf("XUA_Endpoint0_setProductStr() with string %s\n", product_str);
-    concatenateAndCopyStrings(product_str, "", g_product_str);
-}
-
-void XUA_Endpoint0_setSerialStr(char* serial_str) {
-    debug_printf("XUA_Endpoint0_setSerialStr() with string %s\n", serial_str);
-    concatenateAndCopyStrings(serial_str, "", g_serial_str);
-}
-
-char* XUA_Endpoint0_getVendorStr() {
+char* XUA_Endpoint0_getVendorStr()
+{
     return g_strTable.vendorStr;
 }
 
@@ -414,6 +390,7 @@ char* XUA_Endpoint0_getSerialStr()
 {
     return g_strTable.serialStr;
 }
+
 
 /* Note, this sets the same Product ID for both Audio Class 1.0 and Audio Class 2.0.
  * This is unlikely to be desirable.
@@ -527,15 +504,15 @@ void XUA_Endpoint0_init(chanend c_ep0_out, chanend c_ep0_in, NULLABLE_RESOURCE(c
     ep0_out = XUD_InitEp(c_ep0_out);
     ep0_in  = XUD_InitEp(c_ep0_in);
 
-    XUA_Endpoint0_setStrTable();
-
     VendorRequests_Init(VENDOR_REQUESTS_PARAMS);
 #if _XUA_ENABLE_BOS_DESC
     update_guid_in_msos_desc(g_device_interface_guid_dfu_str, g_device_interface_guid_control_str);
 #endif
 
-    if(strcmp(g_strTable.serialStr, "")) // If serialStr is not empty
+    if(strcmp(g_strTable.serialStr, ""))
     {
+        // If serialStr is not empty then point the serial number in the device descriptor to the
+        // string table. iserialNumber is is set to none (0) by default */
 #if (XUA_AUDIO_CLASS_HS == 2) || (XUA_AUDIO_CLASS_FS == 2)
         devDesc_Audio2.iSerialNumber = offsetof(StringDescTable_t, serialStr)/sizeof(char *);
 #endif
@@ -543,7 +520,6 @@ void XUA_Endpoint0_init(chanend c_ep0_out, chanend c_ep0_in, NULLABLE_RESOURCE(c
         devDesc_Audio1.iSerialNumber = offsetof(StringDescTable_t, serialStr)/sizeof(char *);
 #endif
     }
-
 
 #if (MIXER)
     /* Set up mixer default state */

--- a/lib_xua/src/core/endpoint0/xua_ep0_descriptors.h
+++ b/lib_xua/src/core/endpoint0/xua_ep0_descriptors.h
@@ -29,30 +29,22 @@
     #define _XUA_ENABLE_BOS_DESC (0)
 #endif
 
-#define APPEND_VENDOR_STR(x) VENDOR_STR" "#x
-
-#define APPEND_PRODUCT_STR_A2(x) PRODUCT_STR_A2 " "#x
-
-#define APPEND_PRODUCT_STR_A1(x) PRODUCT_STR_A1 " "#x
-
 #define STR_TABLE_ENTRY(name) char * name
 
-// The empty strings below are used in the g_strTable to set the maximum size of the table entries
+// The default strings below are used in the g_strTable to set the maximum size of the table entries
 // The last char of the strings are different, so that the compiler allocates separate memory spaces
-#define XUA_VENDOR_EMPTY_STRING "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\01"
-#define XUA_PRODUCT_EMPTY_STRING "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\02"
-#define XUA_CLOCK_SELECTOR_EMPTY_STRING "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\03"
-#define XUA_INTERNAL_CLOCK_SELECTOR_EMPTY_STRING "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\04"
-#define XUA_SPDIF_CLOCK_SOURCE_EMPTY_STRING "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\05"
-#define XUA_ADAT_CLOCK_SOURCE_EMPTY_STRING "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\06"
-#define XUA_DFU_EMPTY_STRING "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\07"
-#define XUA_CTRL_EMPTY_STRING "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\08"
-#define XUA_MIDI_OUT_EMPTY_STRING "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\09"
-#define XUA_MIDI_IN_EMPTY_STRING "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0a"
-#define XUA_SERIAL_EMPTY_STRING "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0b"
-
-// The value below must match the length of XUA_DESCR_EMPTY_STRING.
-#define XUA_MAX_STR_LEN (32)
+#define XUA_VENDOR_DEFAULT_STRING                VENDOR_STR   "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\01"
+#define XUA_PRODUCT_A1_DEFAULT_STRING            PRODUCT_STR_A1   "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\02"
+#define XUA_PRODUCT_A2_DEFAULT_STRING            PRODUCT_STR_A2   "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\03"
+#define XUA_CLOCK_SELECTOR_DEFAULT_STRING        VENDOR_STR " Clock Selector" "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\04"
+#define XUA_INTERNAL_CLOCK_SOURCE_DEFAULT_STRING VENDOR_STR " Internal Clock" "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\05"
+#define XUA_SPDIF_CLOCK_SOURCE_DEFAULT_STRING    VENDOR_STR " S/PDIF Clock"   "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\06"
+#define XUA_ADAT_CLOCK_SOURCE_DEFAULT_STRING     VENDOR_STR " ADAT Clock"     "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\07"
+#define XUA_DFU_DEFAULT_STRING                   VENDOR_STR " DFU" "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\08"
+#define XUA_CTRL_DEFAULT_STRING                  VENSOR_SRR " Control" "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\09"
+#define XUA_MIDI_OUT_DEFAULT_STRING              VENDOR_STR " MIDI Out" "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0a"
+#define XUA_MIDI_IN_DEFAULT_STRING               VENDOR_STR " MIDI In"  "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0b"
+#define XUA_SERIAL_DEFAULT_STRING                SERIAL_STR "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0c"
 
 #define ISO_EP_ATTRIBUTES_ASYNC                    ((USB_ENDPOINT_TRANSTYPE_ISO << USB_ENDPOINT_TRANSTYPE_SHIFT)\
                                                     | (USB_ENDPOINT_SYNCTYPE_ASYNC << USB_ENDPOINT_SYNCTYPE_SHIFT)\
@@ -353,41 +345,41 @@ typedef struct
 StringDescTable_t g_strTable =
 {
     .langID                      = "\x09\x04", /* US English */
-    .vendorStr                   = XUA_VENDOR_EMPTY_STRING,
-    .serialStr                   = XUA_SERIAL_EMPTY_STRING,
+    .vendorStr                   = XUA_VENDOR_DEFAULT_STRING,
+    .serialStr                   = XUA_SERIAL_DEFAULT_STRING,
 #if (XUA_AUDIO_CLASS_HS == 2) || (XUA_AUDIO_CLASS_FS == 2)
-    .productStr_Audio2           = XUA_PRODUCT_EMPTY_STRING,
-    .outputInterfaceStr_Audio2   = XUA_PRODUCT_EMPTY_STRING,
-    .inputInterfaceStr_Audio2    = XUA_PRODUCT_EMPTY_STRING,
-    .usbInputTermStr_Audio2      = XUA_PRODUCT_EMPTY_STRING,
-    .usbOutputTermStr_Audio2     = XUA_PRODUCT_EMPTY_STRING,
+    .productStr_Audio2           = XUA_PRODUCT_A2_DEFAULT_STRING,
+    .outputInterfaceStr_Audio2   = XUA_PRODUCT_A2_DEFAULT_STRING,
+    .inputInterfaceStr_Audio2    = XUA_PRODUCT_A2_DEFAULT_STRING,
+    .usbInputTermStr_Audio2      = XUA_PRODUCT_A2_DEFAULT_STRING,
+    .usbOutputTermStr_Audio2     = XUA_PRODUCT_A2_DEFAULT_STRING,
 #endif
 #if (XUA_AUDIO_CLASS_FS == 1)
-    .productStr_Audio1           = XUA_PRODUCT_EMPTY_STRING,
-    .outputInterfaceStr_Audio1   = XUA_PRODUCT_EMPTY_STRING,
-    .inputInterfaceStr_Audio1    = XUA_PRODUCT_EMPTY_STRING,
-    .usbInputTermStr_Audio1      = XUA_PRODUCT_EMPTY_STRING,
-    .usbOutputTermStr_Audio1     = XUA_PRODUCT_EMPTY_STRING,
+    .productStr_Audio1           = XUA_PRODUCT_A1_DEFAULT_STRING,
+    .outputInterfaceStr_Audio1   = XUA_PRODUCT_A1_DEFAULT_STRING,
+    .inputInterfaceStr_Audio1    = XUA_PRODUCT_A1_DEFAULT_STRING,
+    .usbInputTermStr_Audio1      = XUA_PRODUCT_A1_DEFAULT_STRING,
+    .usbOutputTermStr_Audio1     = XUA_PRODUCT_A1_DEFAULT_STRING,
 #endif
 #if (XUA_AUDIO_CLASS_HS == 2) || (XUA_AUDIO_CLASS_FS == 2)
-    .clockSelectorStr            = XUA_CLOCK_SELECTOR_EMPTY_STRING,
-    .internalClockSourceStr      = XUA_INTERNAL_CLOCK_SELECTOR_EMPTY_STRING,
+    .clockSelectorStr            = XUA_CLOCK_SELECTOR_DEFAULT_STRING,
+    .internalClockSourceStr      = XUA_INTERNAL_CLOCK_SOURCE_DEFAULT_STRING,
 #if (XUA_SPDIF_RX_EN)
-    .spdifClockSourceStr         = XUA_SPDIF_CLOCK_SOURCE_EMPTY_STRING,
+    .spdifClockSourceStr         = XUA_SPDIF_CLOCK_SOURCE_DEFAULT_STRING,
 #endif
 #if (XUA_ADAT_RX_EN)
-    .adatClockSourceStr          = XUA_ADAT_CLOCK_SOURCE_EMPTY_STRING,
+    .adatClockSourceStr          = XUA_ADAT_CLOCK_SOURCE_DEFAULT_STRING,
 #endif
-#endif // AUDIO_CLASS == 2
+#endif
 #if XUA_DFU_EN
-    .dfuStr                      = XUA_DFU_EMPTY_STRING,
+    .dfuStr                      = XUA_DFU_DEFAULT_STRING,
 #endif
 #if XUA_USB_CONTROL_DESCS
-    .ctrlStr                      = XUA_CTRL_EMPTY_STRING,
+    .ctrlStr                     = XUA_CTRL_DEFAULT_STRING,
 #endif
 #ifdef MIDI
-    .midiOutStr                   = XUA_MIDI_OUT_EMPTY_STRING,
-    .midiInStr                    = XUA_MIDI_IN_EMPTY_STRING,
+    .midiOutStr                  = XUA_MIDI_OUT_DEFAULT_STRING,
+    .midiInStr                   = XUA_MIDI_IN_DEFAULT_STRING,
 #endif
 
     #include "chanstrings.h"
@@ -811,7 +803,7 @@ typedef struct
     0x40,                                 /* 5    wTransferSize */ \
     0x00,                                 /* 6    wTransferSize */ \
     0x10,                                 /* 7    bcdDFUVersion */ \
-    0x01                                /* 7    bcdDFUVersion */
+    0x01                                  /* 7    bcdDFUVersion */
 
 #if (XUA_AUDIO_CLASS_HS == 2) || (XUA_AUDIO_CLASS_FS == 2)
 USB_Config_Descriptor_Audio2_t cfgDesc_Audio2=
@@ -2155,8 +2147,7 @@ unsigned char cfgDesc_Null[] =
 #else
     128,
 #endif
-    _XUA_BMAX_POWER,                           /* 8  bMaxPower */
-
+    _XUA_BMAX_POWER,                      /* 8  bMaxPower */
     0x09,                                 /* 0 bLength : Size of this descriptor, in bytes. (field size 1 bytes) */
     0x04,                                 /* 1 bDescriptorType : INTERFACE descriptor. (field size 1 bytes) */
     0x00,                                 /* 2 bInterfaceNumber : Index of this interface. (field size 1 bytes) */
@@ -2337,8 +2328,7 @@ unsigned char cfgDesc_Audio1[] =
 #else
     128,                                  /* 7  bmAttributes */
 #endif
-    _XUA_BMAX_POWER,                           /* 8  bMaxPower */
-
+    _XUA_BMAX_POWER,                      /* 8  bMaxPower */
 #if ((NUM_USB_CHAN_IN > 0) || (NUM_USB_CHAN_OUT > 0))
     /* Standard AC interface descriptor */
     0x09,

--- a/lib_xua/src/core/endpoint0/xua_ep0_descriptors.h
+++ b/lib_xua/src/core/endpoint0/xua_ep0_descriptors.h
@@ -74,6 +74,11 @@
                                                     | (USB_ENDPOINT_SYNCTYPE_ADAPT << USB_ENDPOINT_SYNCTYPE_SHIFT)\
                                                     | (USB_ENDPOINT_USAGETYPE_IMPLICIT << USB_ENDPOINT_USAGETYPE_SHIFT))
 
+#define FEEDBACK_MAX_PACKET_SIZE_HS    (4)
+#define FEEDBACK_MAX_PACKET_SIZE_FS    (3)
+#define FEEDBACK_INTERVAL_HS           (4)         /* Only values <= 1 frame (4) supported by MS */
+#define FEEDBACK_INTERVAL_FS           (1)         /* Has to be 1 */
+
 #if __STDC__
 typedef struct
 {
@@ -1525,8 +1530,13 @@ USB_Config_Descriptor_Audio2_t cfgDesc_Audio2=
         .bDescriptorType    = USB_DESCTYPE_ENDPOINT,
         .bEndpointAddress   = ENDPOINT_ADDRESS_IN_FEEDBACK,
         .bmAttributes       = 17,         /* (bitmap) */
-        .wMaxPacketSize     = 0x0004,
-        .bInterval          = 4,          /* Only values <= 1 frame (4) supported by MS */
+#if (XUA_USB_BUS_SPEED == 1)
+        .wMaxPacketSize     = FEEDBACK_MAX_PACKET_SIZE_FS,
+        .bInterval          = FEEDBACK_INTERVAL_FS,
+#else
+        .wMaxPacketSize     = FEEDBACK_MAX_PACKET_SIZE_HS,
+        .bInterval          = FEEDBACK_INTERVAL_HS,
+#endif
     },
 #endif
 #if (OUTPUT_FORMAT_COUNT > 1)
@@ -1611,12 +1621,17 @@ USB_Config_Descriptor_Audio2_t cfgDesc_Audio2=
 #if (NUM_USB_CHAN_IN == 0) || defined(UAC_FORCE_FEEDBACK_EP) && (XUA_SYNCMODE == XUA_SYNCMODE_ASYNC)
     .Audio_Out_Fb_Endpoint_2 =
     {
-        0x07,                             /* 0  bLength: 7 */
-        USB_DESCTYPE_ENDPOINT,            /* 1  bDescriptorType: ENDPOINT */
-        ENDPOINT_ADDRESS_IN_FEEDBACK,     /* 2  bEndpointAddress (D7: 0:out, 1:in) */
-        17,                               /* 3  bmAttributes (bitmap)  */
-        0x0004,                           /* 4  wMaxPacketSize */
-        4,                                /* 6  bInterval. Only values <= 1 frame (4) supported by MS */
+        .bLength                       = 0x07,
+        .bDescriptorType               = USB_DESCTYPE_ENDPOINT,
+        .bEndpointAddress              = ENDPOINT_ADDRESS_IN_FEEDBACK,
+        .bmAttributes                  = 17,                   /* (bitmap)  */
+#if (XUA_USB_BUS_SPEED == 1)
+        .wMaxPacketSize                = FEEDBACK_MAX_PACKET_SIZE_FS,
+        .bInterval                     = FEEDBACK_INTERVAL_FS,
+#else
+        .wMaxPacketSize                = FEEDBACK_MAX_PACKET_SIZE_HS,
+        .bInterval                     = FEEDBACK_INTERVAL_HS,
+#endif
     },
 #endif
 #endif /* OUTPUT_FORMAT_COUNT > 1 */
@@ -1707,8 +1722,13 @@ USB_Config_Descriptor_Audio2_t cfgDesc_Audio2=
         .bDescriptorType               = USB_DESCTYPE_ENDPOINT,
         .bEndpointAddress              = ENDPOINT_ADDRESS_IN_FEEDBACK,
         .bmAttributes                  = 17,                   /* (bitmap)  */
-        .wMaxPacketSize                = 0x0004,
-        .bInterval                     = 4,                    /* Only values <= 1 frame (4) supported by MS */
+#if (XUA_USB_BUS_SPEED == 1)
+        .wMaxPacketSize                = FEEDBACK_MAX_PACKET_SIZE_FS,
+        .bInterval                     = FEEDBACK_INTERVAL_FS,
+#else
+        .wMaxPacketSize                = FEEDBACK_MAX_PACKET_SIZE_HS,
+        .bInterval                     = FEEDBACK_INTERVAL_HS,
+#endif
     },
 #endif
 #endif /* OUTPUT_FORMAT_COUNT > 2 */


### PR DESCRIPTION
- Fixed issue where product string for UAC1 and UAC2 was shared
- Removed superfluous global variables for storing vendor string, product string and serial string.
- Fixed strings not updating at runtime when using the Set API functions (#406)
- Removed run time default string concat and just used the preprocessor
- Simplified string copy/cat function
- Fixed issue with strings related to items such as Clock Selector, Clock, DFU, etc were not updated with setVendorString()
