### PR TITLE
lib_xud’s USB_TILE derived from lib_xua’s XUD_TILE using xud_conf.h

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -30,6 +30,8 @@ UNRELEASED
   * CHANGED:   Functionality associated with AUDIO_CLASS_FALLBACK and
     FULL_SPEED_AUDIO_2 moved to XUA_AUDIO_CLASS_FS and XUA_AUDIO_CLASS_HS
   * CHANGED:   Simplification of USB string table handling
+  * CHANGED:   lib_xud's USB_TILE define derived from lib_xua's XUD_TILE define
+    (using xud_conf.h)
   * FIXED:     wMaxPacketSize for MIDI bulk IN and OUT endpoints incorrectly
     set when running at full-speed
   * FIXED:     `p_mclk_in` and `clk_audio_bclk` not correctly nullable when I2S
@@ -51,7 +53,7 @@ UNRELEASED
     for audio out endpoint occurred if additional custom endpoints are added
   * FIXED:     String descriptors not updated when using runtime API (#406)
   * FIXED:     Strings relating to items such as Clock Selector, Clock, DFU, etc
-               not updated when using run time API function setVendorString()
+    not updated when using run time API function setVendorString()
   * REMOVED:   Support for iAP EA Native Transport endpoints
 
 5.0.0

--- a/lib_xua/lib_build_info.cmake
+++ b/lib_xua/lib_build_info.cmake
@@ -1,6 +1,7 @@
 set(LIB_NAME lib_xua)
 set(LIB_VERSION 5.0.0)
 set(LIB_INCLUDES api
+                 src
                  src/core
                  src/core/audiohub
                  src/core/buffer/ep
@@ -20,11 +21,13 @@ set(LIB_INCLUDES api
                  src/core/user/suspend
                  src/hid
                  src/midi)
+
 set(LIB_OPTIONAL_HEADERS    xua_conf.h
                             static_hid_report.h
                             user_main_globals.h
                             user_main_declarations.h
                             user_main_cores.h)
+
 set(LIB_DEPENDENT_MODULES "lib_adat(2.0.1)"
                           "lib_locks(2.3.1)"
                           "lib_logging(3.3.1)"

--- a/lib_xua/module_build_info
+++ b/lib_xua/module_build_info
@@ -12,9 +12,9 @@ DEPENDENT_MODULES = lib_adat(>=2.0.1) \
                     lib_locks(>=2.3.1) \
                     lib_logging(>=3.3.1) \
                     lib_spdif(>=6.2.1) \
-                    lib_sw_pll(>=2.3.1) \
+                    lib_sw_pll(>=2.4.0) \
                     lib_xassert(>=4.3.1) \
-                    lib_xud(>=2.4.0) \
+                    lib_xud(>=3.0.0) \
                     lib_mic_array(>=5.5.0)
 
 MODULE_XCC_FLAGS = $(XCC_FLAGS) \

--- a/lib_xua/module_build_info
+++ b/lib_xua/module_build_info
@@ -58,7 +58,8 @@ INCLUDE_DIRS = $(EXPORT_INCLUDE_DIRS) \
                src/core/user/hostactive \
                src/core/user/suspend \
                src/hid \
-               src/midi
+               src/midi \
+               src
 
 SOURCE_DIRS = src/core \
               src/core/audiohub \

--- a/lib_xua/src/xud_conf.h
+++ b/lib_xua/src/xud_conf.h
@@ -1,0 +1,12 @@
+// Copyright 2025 XMOS LIMITED.
+// This Software is subject to the terms of the XMOS Public Licence: Version 1.
+
+#ifndef _XUD_CONF_H_
+#define _XUD_CONF_H_
+
+#include "xua_conf_full.h"
+
+/* Link lib_xua's XUD_TILE to lib_xud's USB_TILE */
+#define USB_TILE tile[XUD_TILE]
+
+#endif

--- a/tests/xua_sim_tests/test_i2s_loopback/CMakeLists.txt
+++ b/tests/xua_sim_tests/test_i2s_loopback/CMakeLists.txt
@@ -27,7 +27,6 @@ set(COMMON_FLAGS -O3
                  -lflash
                  -DXUD_CORE_CLOCK=600
                  -fxscope
-                 -DUSB_TILE=tile[1]
                  -DSIMULATION=1)
 
 file(READ ${CMAKE_CURRENT_LIST_DIR}/../i2s_loopback_params.json params_json)

--- a/tests/xua_sim_tests/test_midi/src/xud_conf.h
+++ b/tests/xua_sim_tests/test_midi/src/xud_conf.h
@@ -1,8 +1,0 @@
-// Copyright 2017-2025 XMOS LIMITED.
-// This Software is subject to the terms of the XMOS Public Licence: Version 1.
-
-#include "xua_conf.h"
-
-/* TODO */
-#define XUD_UAC_NUM_USB_CHAN_OUT    NUM_USB_CHAN_OUT
-#define XUD_UAC_NUM_USB_CHAN_IN     NUM_USB_CHAN_IN

--- a/tests/xua_sim_tests/test_mixer_routing_input/src/xua_conf.h
+++ b/tests/xua_sim_tests/test_mixer_routing_input/src/xua_conf.h
@@ -15,7 +15,7 @@
 
 #define UAC_FORCE_FEEDBACK_EP   (0)
 #define XUA_NUM_PDM_MICS 0
-#define XUD_TILE 1
+#define XUD_TILE 0
 #define AUDIO_IO_TILE 0
 
 #ifndef MCLK_441

--- a/tests/xua_sim_tests/test_mixer_routing_input_ctrl/src/xua_conf.h
+++ b/tests/xua_sim_tests/test_mixer_routing_input_ctrl/src/xua_conf.h
@@ -15,7 +15,7 @@
 
 #define UAC_FORCE_FEEDBACK_EP   (0)
 #define XUA_NUM_PDM_MICS 0
-#define XUD_TILE 1
+#define XUD_TILE 0
 #define AUDIO_IO_TILE 0
 
 #ifndef MCLK_441

--- a/tests/xua_sim_tests/test_mixer_routing_output/src/xua_conf.h
+++ b/tests/xua_sim_tests/test_mixer_routing_output/src/xua_conf.h
@@ -15,7 +15,7 @@
 
 #define UAC_FORCE_FEEDBACK_EP   (0)
 #define XUA_NUM_PDM_MICS 0
-#define XUD_TILE 1
+#define XUD_TILE 0
 #define AUDIO_IO_TILE 0
 
 #ifndef MCLK_441

--- a/tests/xua_sim_tests/test_mixer_routing_output_ctrl/src/xua_conf.h
+++ b/tests/xua_sim_tests/test_mixer_routing_output_ctrl/src/xua_conf.h
@@ -15,7 +15,7 @@
 
 #define UAC_FORCE_FEEDBACK_EP   (0)
 #define XUA_NUM_PDM_MICS 0
-#define XUD_TILE 1
+#define XUD_TILE 0
 #define AUDIO_IO_TILE 0
 
 #ifndef MCLK_441

--- a/tests/xua_sim_tests/test_sync_clk_basic/CMakeLists.txt
+++ b/tests/xua_sim_tests/test_sync_clk_basic/CMakeLists.txt
@@ -7,7 +7,6 @@ set(APP_HW_TARGET test_xs3_600.xn)
 set(APP_INCLUDES src)
 
 set(COMMON_FLAGS -O3 -g -DXUD_CORE_CLOCK=600
-                 -DUSB_TILE=tile[0]
                  -DLOCAL_CLOCK_INCREMENT=10000
                  -DLOCAL_CLOCK_MARGIN=100
                  -DXUA_USE_SW_PLL=0)

--- a/tests/xua_sim_tests/test_sync_clk_basic/src/xua_conf.h
+++ b/tests/xua_sim_tests/test_sync_clk_basic/src/xua_conf.h
@@ -13,7 +13,7 @@
 
 #define EXCLUDE_USB_AUDIO_MAIN
 #define XUA_NUM_PDM_MICS 0
-#define XUD_TILE 1
+#define XUD_TILE 0
 #define AUDIO_IO_TILE 0
 #define MIXER 0
 

--- a/tests/xua_sim_tests/test_sync_clk_plugin/CMakeLists.txt
+++ b/tests/xua_sim_tests/test_sync_clk_plugin/CMakeLists.txt
@@ -7,7 +7,6 @@ set(APP_HW_TARGET test_xs3_600.xn)
 set(APP_INCLUDES src)
 
 set(COMMON_FLAGS -O3 -g -DXUD_CORE_CLOCK=600
-                 -DUSB_TILE=tile[0]
                  -DLOCAL_CLOCK_INCREMENT=10000
                  -DLOCAL_CLOCK_MARGIN=100
                  -DXUA_USE_SW_PLL=0

--- a/tests/xua_sim_tests/test_sync_clk_plugin/src/xua_conf.h
+++ b/tests/xua_sim_tests/test_sync_clk_plugin/src/xua_conf.h
@@ -13,7 +13,7 @@
 
 #define EXCLUDE_USB_AUDIO_MAIN
 #define XUA_NUM_PDM_MICS 0
-#define XUD_TILE 1
+#define XUD_TILE 0
 #define AUDIO_IO_TILE 0
 #define MIXER 0
 

--- a/tests/xua_unit_tests/CMakeLists.txt
+++ b/tests/xua_unit_tests/CMakeLists.txt
@@ -16,7 +16,6 @@ set(APP_COMPILER_FLAGS -fcomment-asm
                        -report
                        -g
                        -fxscope
-                       -DUSB_TILE=tile[0]
                        -DUNITY_SUPPORT_64
                        -DUNITY_INCLUDE_DOUBLE
                        -DXUD_CORE_CLOCK=600


### PR DESCRIPTION
Addresses #428

Some tests needed to be updated as they had XUD_TILE set to 1, causing a build issue if there was no mult-tile main. 