### PR TITLE
_XUA_BMAX_POWER -> XUA_BMAX_POWER 

### DIFF
--- a/lib_xua/api/xua_conf_default.h
+++ b/lib_xua/api/xua_conf_default.h
@@ -1195,13 +1195,13 @@
  */
 #if (XUA_POWERMODE == XUA_POWERMODE_SELF)
     /* Default to taking no power from the bus in self-powered mode */
-    #ifndef _XUA_BMAX_POWER
-        #define _XUA_BMAX_POWER     (0)
+    #ifndef XUA_BMAX_POWER
+        #define XUA_BMAX_POWER     (0)
     #endif
 #else
     /* Default to taking 500mA from the bus in bus-powered mode */
-    #ifndef _XUA_BMAX_POWER
-        #define _XUA_BMAX_POWER      (250)
+    #ifndef XUA_BMAX_POWER
+        #define XUA_BMAX_POWER      (250)
     #endif
 #endif
 

--- a/lib_xua/src/core/endpoint0/xua_ep0_descriptors.h
+++ b/lib_xua/src/core/endpoint0/xua_ep0_descriptors.h
@@ -821,7 +821,7 @@ USB_Config_Descriptor_Audio2_t cfgDesc_Audio2=
 #else
         .bmAttributes               = 128,
 #endif
-        .bMaxPower                  = _XUA_BMAX_POWER,
+        .bMaxPower                  = XUA_BMAX_POWER,
     },
 
 #if (NUM_USB_CHAN_OUT > 0) || (NUM_USB_CHAN_IN > 0)
@@ -2150,7 +2150,7 @@ unsigned char cfgDesc_Null[] =
 #else
     128,
 #endif
-    _XUA_BMAX_POWER,                      /* 8  bMaxPower */
+    XUA_BMAX_POWER,                      /* 8  bMaxPower */
     0x09,                                 /* 0 bLength : Size of this descriptor, in bytes. (field size 1 bytes) */
     0x04,                                 /* 1 bDescriptorType : INTERFACE descriptor. (field size 1 bytes) */
     0x00,                                 /* 2 bInterfaceNumber : Index of this interface. (field size 1 bytes) */
@@ -2331,7 +2331,7 @@ unsigned char cfgDesc_Audio1[] =
 #else
     128,                                  /* 7  bmAttributes */
 #endif
-    _XUA_BMAX_POWER,                      /* 8  bMaxPower */
+    XUA_BMAX_POWER,                      /* 8  bMaxPower */
 #if ((NUM_USB_CHAN_IN > 0) || (NUM_USB_CHAN_OUT > 0))
     /* Standard AC interface descriptor */
     0x09,

--- a/lib_xua/src/dfu/xua_dfu.h
+++ b/lib_xua/src/dfu/xua_dfu.h
@@ -87,7 +87,7 @@ USB_Config_Descriptor_DFU_t DFUcfgDesc = {
 #else
         .bmAttributes               = 128,
 #endif
-        .bMaxPower                  = _XUA_BMAX_POWER,
+        .bMaxPower                  = XUA_BMAX_POWER,
     },
     .InterfaceDesc =
     {


### PR DESCRIPTION
Users may wish to set this. We use _ prefix for internal defines, not ones part of the API. 

