### PR TITLE
Reset counters and reset_sw_pll_pfd when external clock goes invalid in clockgen

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ UNRELEASED
 ----------
 
   * FIXED: Issue with MCLK not present for digital RX only configs when using the software PLL
+  * FIXED: Reset SW PLL phase/frequency detector when digital clock becomes invalid to prevent incorrect error input to sigma-delta modulator
 
 5.1.0
 -----

--- a/lib_xua/src/core/clocking/clockgen.xc
+++ b/lib_xua/src/core/clocking/clockgen.xc
@@ -229,8 +229,10 @@ void clockGen ( streaming chanend ?c_spdif_rx,
 #endif
 )
 {
+#if !XUA_USE_SW_PLL
     timer t_local;
-    unsigned timeNextEdge, timeLastEdge, timeNextClockDetection;
+    unsigned timeNextEdge, timeLastEdge;
+#endif
     unsigned clkMode = CLOCK_INTERNAL;              /* Current clocking mode in operation */
     unsigned tmp;
 
@@ -260,6 +262,7 @@ void clockGen ( streaming chanend ?c_spdif_rx,
 
 #if (XUA_SPDIF_RX_EN || XUA_ADAT_RX_EN)
     timer t_external;
+    unsigned timeNextClockDetection;
     unsigned selected_mclk_rate = MCLK_48; // Assume 24.576MHz initial clock
     unsigned selected_sample_rate = 0;
 #if XUA_USE_SW_PLL
@@ -281,7 +284,9 @@ void clockGen ( streaming chanend ?c_spdif_rx,
     int spdifUnderflow = 1;
     int spdifSamps = 0;                            /* Number of samples in buffer */
     Counter spdifCounters;
+#if !XUA_USE_SW_PLL
     int spdifRxTime;
+#endif
     unsigned tmp2;
     unsigned spdifLeft = 0;
     unsigned spdifRxData;
@@ -297,7 +302,9 @@ void clockGen ( streaming chanend ?c_spdif_rx,
     //int adatFrameErrors = 0;
     int adatSamps = 0;
     Counter adatCounters;
+#if !XUA_USE_SW_PLL
     int adatReceivedTime;
+#endif
 
     unsigned adatFrame[8];
     int adatChannel = 0;
@@ -343,10 +350,19 @@ void clockGen ( streaming chanend ?c_spdif_rx,
     adatCounters.samplesPerTick = 0;
 #endif
 
+#if !XUA_USE_SW_PLL
     t_local :> timeNextEdge;
     timeLastEdge = timeNextEdge;
+#if (XUA_SPDIF_RX_EN || XUA_ADAT_RX_EN)
     timeNextClockDetection = timeNextEdge + (LOCAL_CLOCK_INCREMENT / 2);
+#endif
     timeNextEdge += LOCAL_CLOCK_INCREMENT;
+#else
+#if (XUA_SPDIF_RX_EN || XUA_ADAT_RX_EN)
+    t_external :> timeNextClockDetection;
+    timeNextClockDetection += LOCAL_CLOCK_INCREMENT;
+#endif
+#endif
 
 #ifdef LEVEL_METER_LEDS
     t_level :> levelTime;
@@ -482,19 +498,18 @@ void clockGen ( streaming chanend ?c_spdif_rx,
                 break;
 
             /* Generate local clock from timer */
+#if !XUA_USE_SW_PLL
             case t_local when timerafter(timeNextEdge) :> void:
-
-#if XUA_USE_SW_PLL
-                /* Do nothing - hold the most recent sw_pll setting */
-#else
                 /* Setup next local clock edge */
                 i_pll_ref.toggle_timed(0);
-#endif
+
                 /* Record time of edge */
                 timeLastEdge = timeNextEdge;
 
                 /* Setup for next edge */
+#if (XUA_SPDIF_RX_EN || XUA_ADAT_RX_EN)
                 timeNextClockDetection = timeNextEdge + (LOCAL_CLOCK_INCREMENT/2);
+#endif
                 timeNextEdge += LOCAL_CLOCK_INCREMENT;
 
                 /* If we are in an external clock mode and this fire, then clock invalid
@@ -515,6 +530,7 @@ void clockGen ( streaming chanend ?c_spdif_rx,
                 }
 #endif
                 break;
+#endif
 
 #if (XUA_SPDIF_RX_EN || XUA_ADAT_RX_EN)
             case t_external when timerafter(timeNextClockDetection) :> void:
@@ -524,11 +540,29 @@ void clockGen ( streaming chanend ?c_spdif_rx,
 #if (XUA_SPDIF_RX_EN)
                     /* Returns 1 if valid clock found */
                     valid = validSamples(spdifCounters, CLOCK_SPDIF);
+#if XUA_USE_SW_PLL
+                    if(clockValid[CLOCK_SPDIF] && (valid == 0))
+                    {
+                        /* Skip first measurement when clock goes valid next as the mclk_time_stamp
+                        will be very off wrt the last_mclk_time_stamp which was recorded when the
+                        clock was last valid
+                        */
+                        reset_sw_pll_pfd = 1;
+                        spdifCounters.receivedSamples = 0;
+                    }
+#endif
                     setClockValidity(c_clk_int, CLOCK_SPDIF, valid, clkMode);
 #endif
 #if (XUA_ADAT_RX_EN)
                     /* Returns 1 if valid clock found */
                     valid = validSamples(adatCounters, CLOCK_ADAT);
+#if XUA_USE_SW_PLL
+                    if(clockValid[CLOCK_ADAT] && (valid == 0))
+                    {
+                        reset_sw_pll_pfd = 1;
+                        adatCounters.receivedSamples = 0;
+                    }
+#endif
                     setClockValidity(c_clk_int, CLOCK_ADAT, valid, clkMode);
 #endif
                 }
@@ -572,8 +606,9 @@ void clockGen ( streaming chanend ?c_spdif_rx,
 #if XUA_USE_SW_PLL
                 /* Record time of sample */
                 asm volatile(" getts %0, res[%1]" : "=r" (mclk_time_stamp) : "r" (p_for_mclk_count_aud));
-#endif
+#else
                 t_local :> spdifRxTime;
+#endif
 
                 /* Check parity and ignore if bad */
                 if(spdif_rx_check_parity(spdifRxData))
@@ -633,6 +668,15 @@ void clockGen ( streaming chanend ?c_spdif_rx,
                     /* Inspect for if we need to produce an edge */
                     if((spdifCounters.receivedSamples >=  spdifCounters.samplesPerTick))
                     {
+#if XUA_USE_SW_PLL
+                        do_sw_pll_phase_frequency_detector_dig_rx(  mclk_time_stamp,
+                                            mclks_per_sample,
+                                            c_sw_pll,
+                                            spdifCounters.receivedSamples,
+                                            reset_sw_pll_pfd);
+                        /* Reset counters */
+                        spdifCounters.receivedSamples = 0;
+#else
                         /* Check edge is about right... S/PDIF may have changed freq... */
                         if(timeafter(spdifRxTime, (timeLastEdge + LOCAL_CLOCK_INCREMENT - LOCAL_CLOCK_MARGIN)))
                         {
@@ -642,19 +686,13 @@ void clockGen ( streaming chanend ?c_spdif_rx,
                             /* Setup for next edge */
                             timeNextEdge = spdifRxTime + LOCAL_CLOCK_INCREMENT + LOCAL_CLOCK_MARGIN;
 
-#if XUA_USE_SW_PLL
-                            do_sw_pll_phase_frequency_detector_dig_rx(  mclk_time_stamp,
-                                                                        mclks_per_sample,
-                                                                        c_sw_pll,
-                                                                        spdifCounters.receivedSamples,
-                                                                        reset_sw_pll_pfd);
-#else
                             /* Toggle edge */
                             i_pll_ref.toggle_timed(1);
-#endif
+
                             /* Reset counters */
                             spdifCounters.receivedSamples = 0;
                         }
+#endif
                     }
                 }
                 break;
@@ -665,8 +703,9 @@ void clockGen ( streaming chanend ?c_spdif_rx,
 #if XUA_USE_SW_PLL
                     /* record time of sample */
                     asm volatile(" getts %0, res[%1]" : "=r" (mclk_time_stamp) : "r" (p_for_mclk_count_aud));
-#endif
+#else
                     t_local :> adatReceivedTime;
+#endif
 
                     /* Sync is: 1 | (user_byte << 4) */
                     if(tmp&1)
@@ -756,6 +795,16 @@ void clockGen ( streaming chanend ?c_spdif_rx,
                                     /* Inspect for if we need to produce an edge */
                                     if ((adatCounters.receivedSamples >= adatCounters.samplesPerTick))
                                     {
+#if XUA_USE_SW_PLL
+                                        do_sw_pll_phase_frequency_detector_dig_rx(  mclk_time_stamp,
+                                            mclks_per_sample,
+                                            c_sw_pll,
+                                            adatCounters.receivedSamples,
+                                            reset_sw_pll_pfd);
+
+                                        /* Reset counters */
+                                        adatCounters.receivedSamples = 0;
+#else
                                         /* Check edge is about right... ADAT may have changed freq... */
                                         if (timeafter(adatReceivedTime, (timeLastEdge + LOCAL_CLOCK_INCREMENT - LOCAL_CLOCK_MARGIN)))
                                         {
@@ -765,20 +814,13 @@ void clockGen ( streaming chanend ?c_spdif_rx,
                                             /* Setup for next edge */
                                             timeNextEdge = adatReceivedTime + LOCAL_CLOCK_INCREMENT + LOCAL_CLOCK_MARGIN;
 
-#if XUA_USE_SW_PLL
-                                            do_sw_pll_phase_frequency_detector_dig_rx(  mclk_time_stamp,
-                                                                                        mclks_per_sample,
-                                                                                        c_sw_pll,
-                                                                                        adatCounters.receivedSamples,
-                                                                                        reset_sw_pll_pfd);
-#else
                                             /* Toggle edge */
                                             i_pll_ref.toggle_timed(1);
-#endif
 
                                             /* Reset counters */
                                             adatCounters.receivedSamples = 0;
                                         }
+#endif
                                     }
                                 }
                             }


### PR DESCRIPTION
also, addresses https://github.com/xmos/lib_xua/issues/500