### PR TITLE
Ensure mclk is there on audio tile when digital rx + sw_pll enabled

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 lib_xua change log
 ==================
 
+UNRELEASED
+----------
+
+  * FIXED: Issue with MCLK not present for digital RX only configs when using the software PLL
+
 5.1.0
 -----
 

--- a/lib_xua/api/xua_conf_default.h
+++ b/lib_xua/api/xua_conf_default.h
@@ -1472,7 +1472,6 @@ enum USBEndpointNumber_Out
 #else
 #define DFU_PRODUCT_STR_INDEX       offsetof(StringDescTable_t, productStr_Audio1)/sizeof(char *)
 #endif
-#endif
 
 /* USB test mode support enabled by default (Required for compliance testing) */
 #if defined(TEST_MODE_SUPPORT) && (TEST_MODE_SUPPORT == 0)
@@ -1729,3 +1728,34 @@ enum USBEndpointNumber_Out
 #define ENUMERATE_CONTROL_INTF_AS_WINUSB    1
 #endif
 
+/**
+ * @brief Macro specifying if an mclk input and a second mclk input are required
+ */
+#define _NEED_MCLK_FOR_I2S \
+  (((I2S_CHANS_DAC != 0) || (I2S_CHANS_ADC != 0)) && (!CODEC_MASTER))
+
+#define _NEED_MCLK_FOR_DIG_RX \
+  (XUA_USE_SW_PLL && (XUA_ADAT_RX_EN || XUA_SPDIF_RX_EN))
+
+#define _NEED_MCLK_FOR_ADAT_TX (XUA_ADAT_TX_EN)
+#define _NEED_MCLK_FOR_SPDIF_TX (XUA_SPDIF_TX_EN)
+#define _NEED_MCLK_FOR_USB (XUA_USB_EN)
+
+/* Need mclk */
+#define MCLK_REQUIRED ( \
+    (_NEED_MCLK_FOR_I2S) || \
+    (_NEED_MCLK_FOR_DIG_RX) || \
+    (_NEED_MCLK_FOR_ADAT_TX) || \
+    (_NEED_MCLK_FOR_SPDIF_TX && (SPDIF_TX_TILE == AUDIO_IO_TILE)) || \
+    (_NEED_MCLK_FOR_USB && (AUDIO_IO_TILE == XUD_TILE)) \
+)
+
+/* Need second mclk -
+ - USB is enabled and present on a different tile than audio, a second mclk will be needed for USB feedback calculation
+ - SPDIF TX is enabled and present on a different tile than audio */
+#define SECOND_MCLK_REQUIRED ( \
+    (_NEED_MCLK_FOR_USB && (XUD_TILE != AUDIO_IO_TILE)) || \
+    (_NEED_MCLK_FOR_SPDIF_TX && (SPDIF_TX_TILE != AUDIO_IO_TILE)) \
+)
+
+#endif /* _XUA_CONF_DEFAULT_H_ */

--- a/lib_xua/src/core/audiohub/xua_audiohub.xc
+++ b/lib_xua/src/core/audiohub/xua_audiohub.xc
@@ -784,7 +784,7 @@ void XUA_AudioHub(chanend ?c_aud, clock ?clk_audio_mclk, clock ?clk_audio_bclk,
         }
 #endif
 
-#if ((AUDIO_IO_TILE == XUD_TILE) || XUA_ADAT_TX_EN || XUA_SPDIF_TX_EN)
+#if (MCLK_REQUIRED)
         xassert((!isnull(clk_audio_mclk) && !isnull(p_mclk_in)) && "Error: must provide non-null MCLK port and MCLK clock-block if digital Rx is enabled or AUDIO_IO_TILE==XUD_TILE");
         /* Clock master clock-block from master-clock port */
         configure_clock_src(clk_audio_mclk, p_mclk_in);
@@ -800,7 +800,7 @@ void XUA_AudioHub(chanend ?c_aud, clock ?clk_audio_mclk, clock ?clk_audio_bclk,
         directly from the MCLK port. */
         /* Start the master clock-block */
         start_clock(clk_audio_mclk);
-#endif /* ((AUDIO_IO_TILE == XUD_TILE) || XUA_ADAT_TX_EN || XUA_SPDIF_TX_EN) */
+#endif /* (MCLK_REQUIRED) */
 
         /* Perform required CODEC/ADC/DAC initialisation */
         AudioHwInit();
@@ -1080,7 +1080,7 @@ void XUA_AudioHub(chanend ?c_aud, clock ?clk_audio_mclk, clock ?clk_audio_bclk,
         }
 #endif // (I2S_CHANS_DAC != 0) || (I2S_CHANS_ADC != 0)
 
-#if ((AUDIO_IO_TILE == XUD_TILE) || XUA_ADAT_TX_EN || XUA_SPDIF_TX_EN)
+#if (MCLK_REQUIRED)
         /* Start the master clock-block */
         stop_clock(clk_audio_mclk);
 #endif

--- a/lib_xua/src/core/main.xc
+++ b/lib_xua/src/core/main.xc
@@ -114,14 +114,14 @@ on tile[AUDIO_IO_TILE] : buffered out port:32 p_lrclk       = PORT_I2S_LRCLK;
 on tile[AUDIO_IO_TILE] : buffered out port:32 p_bclk        = PORT_I2S_BCLK;
 #endif
 
-#if (!CODEC_MASTER) || XUA_SPDIF_TX_EN || XUA_ADAT_TX_EN || ((AUDIO_IO_TILE == XUD_TILE) && XUA_USB_EN)
+#if (MCLK_REQUIRED)
 /* Audio master clock input */
 on tile[AUDIO_IO_TILE] :  in port p_mclk_in                 = PORT_MCLK_IN;
 #else
 #define p_mclk_in null
 #endif
 
-#if (AUDIO_IO_TILE != XUD_TILE) && XUA_USB_EN
+#if (SECOND_MCLK_REQUIRED)
 /* If audio I/O and USB running on different tiles we need a separate port for
  * the master clock input (to use for USB async feedback calculation) */
 on tile[XUD_TILE] : in port p_mclk_in_usb                   = PORT_MCLK_IN_USB;
@@ -523,7 +523,7 @@ int main()
 
                 /* Attach mclk count port to mclk clock-block (for feedback) */
                 //set_port_clock(p_for_mclk_count, clk_audio_mclk);
-#if(AUDIO_IO_TILE != XUD_TILE)
+#if(SECOND_MCLK_REQUIRED)
                 set_clock_src(clk_audio_mclk_usb, p_mclk_in_usb);
                 set_port_clock(p_for_mclk_count, clk_audio_mclk_usb);
                 start_clock(clk_audio_mclk_usb);


### PR DESCRIPTION
Added AUDIO_TILE_MCLK_REQUIRED macro