### PR TITLE
Remove flash info from .xn files

### DIFF
--- a/examples/AN00246_xua_example/src/xk-audio-316-mc.xn
+++ b/examples/AN00246_xua_example/src/xk-audio-316-mc.xn
@@ -80,7 +80,7 @@
     </Link>
   </Links>
   <ExternalDevices>
-      <Device NodeId="0" Tile="0" Class="SQIFlash" Name="bootFlash" PageSize="256" SectorSize="4096" NumPages="16384">
+      <Device NodeId="0" Tile="0" Class="SQIFlash" Name="bootFlash">
       <Attribute Name="PORT_SQI_CS" Value="PORT_SQI_CS"/>
       <Attribute Name="PORT_SQI_SCLK"   Value="PORT_SQI_SCLK"/>
       <Attribute Name="PORT_SQI_SIO"  Value="PORT_SQI_SIO"/>

--- a/examples/AN00247_xua_example_spdif_tx/src/xk-audio-316-mc.xn
+++ b/examples/AN00247_xua_example_spdif_tx/src/xk-audio-316-mc.xn
@@ -80,7 +80,7 @@
     </Link>
   </Links>
   <ExternalDevices>
-      <Device NodeId="0" Tile="0" Class="SQIFlash" Name="bootFlash" PageSize="256" SectorSize="4096" NumPages="16384">
+      <Device NodeId="0" Tile="0" Class="SQIFlash" Name="bootFlash">
       <Attribute Name="PORT_SQI_CS" Value="PORT_SQI_CS"/>
       <Attribute Name="PORT_SQI_SCLK"   Value="PORT_SQI_SCLK"/>
       <Attribute Name="PORT_SQI_SIO"  Value="PORT_SQI_SIO"/>

--- a/tests/xua_hw_tests/test_control/device/src/xk-audio-316-mc.xn
+++ b/tests/xua_hw_tests/test_control/device/src/xk-audio-316-mc.xn
@@ -80,7 +80,7 @@
     </Link>
   </Links>
   <ExternalDevices>
-      <Device NodeId="0" Tile="0" Class="SQIFlash" Name="bootFlash" PageSize="256" SectorSize="4096" NumPages="16384">
+      <Device NodeId="0" Tile="0" Class="SQIFlash" Name="bootFlash">
       <Attribute Name="PORT_SQI_CS" Value="PORT_SQI_CS"/>
       <Attribute Name="PORT_SQI_SCLK"   Value="PORT_SQI_SCLK"/>
       <Attribute Name="PORT_SQI_SIO"  Value="PORT_SQI_SIO"/>

--- a/tests/xua_hw_tests/test_dfu/src/xk-audio-316-mc.xn
+++ b/tests/xua_hw_tests/test_dfu/src/xk-audio-316-mc.xn
@@ -80,7 +80,7 @@
     </Link>
   </Links>
   <ExternalDevices>
-      <Device NodeId="0" Tile="0" Class="SQIFlash" Name="bootFlash" PageSize="256" SectorSize="4096" NumPages="16384">
+      <Device NodeId="0" Tile="0" Class="SQIFlash" Name="bootFlash">
       <Attribute Name="PORT_SQI_CS" Value="PORT_SQI_CS"/>
       <Attribute Name="PORT_SQI_SCLK"   Value="PORT_SQI_SCLK"/>
       <Attribute Name="PORT_SQI_SIO"  Value="PORT_SQI_SIO"/>

--- a/tests/xua_sim_tests/test_i2s_loopback/src/xk_216_mc/xk-audio-216-mc.xn
+++ b/tests/xua_sim_tests/test_i2s_loopback/src/xk_216_mc/xk-audio-216-mc.xn
@@ -83,7 +83,7 @@
     </Link>
   </Links>
   <ExternalDevices>
-    <Device NodeId="0" Tile="0" Class="SQIFlash" Name="bootFlash" Type="S25FL116K" PageSize="256" SectorSize="4096" NumPages="8192">
+    <Device NodeId="0" Tile="0" Class="SQIFlash" Name="bootFlash">
       <Attribute Name="PORT_SQI_CS" Value="PORT_SQI_CS"/>
       <Attribute Name="PORT_SQI_SCLK"   Value="PORT_SQI_SCLK"/>
       <Attribute Name="PORT_SQI_SIO"  Value="PORT_SQI_SIO"/>


### PR DESCRIPTION
From [LSM-103](https://xmosjira.atlassian.net/browse/LSM-103)

Since XTC 15.2.1, we use SFDP to get information about the flash chip on the board, so including this information in the .xn files is no longer necessary. This PR removes that information from those files so tools like xflash don't give warnings that this information is present.

[LSM-103]: https://xmosjira.atlassian.net/browse/LSM-103?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ