### PR TITLE
Add support for a USER_MAIN_TASKS and user_main_tasks.h.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,8 +4,17 @@ lib_xua change log
 UNRELEASED
 ----------
 
-  * FIXED: Issue with MCLK not present for digital RX only configs when using the software PLL
-  * FIXED: Reset SW PLL phase/frequency detector when digital clock becomes invalid to prevent incorrect error input to sigma-delta modulator
+  * ADDED: Support for optional include header `user_main_tasks.h` with the same
+    functionality as `user_main_cores.h` i.e. to allow insertion of tasks into
+    the `main()` function (`user_main_cores.h` to be deprecated in a future
+    release)
+    ADDED: Support for define `USER_MAIN_TASKS` with the same functionalty as
+    `USER_MAIN_CORES` i.e. to allow insertion of tasks into the `main()`
+    function (`USER_MAIN_CORES` to be deprecated in a future release)
+  * FIXED: Issue with MCLK not present for digital RX only configs when using
+    the software PLL
+  * FIXED: Reset SW PLL phase/frequency detector when digital clock becomes
+    invalid to prevent incorrect error input to sigma-delta modulator
 
 5.1.0
 -----

--- a/doc/rst/using.rst
+++ b/doc/rst/using.rst
@@ -4,14 +4,15 @@
 Basic Usage
 ***********
 
-This section describes the basic usage of `lib_xua` and provides a guide on how to program USB Audio devices.
+This section describes the basic usage of `lib_xua` and provides a guide on how to program USB
+Audio devices.
 
 Library Structure
 =================
 
 The code is split into several directories.
 
-.. list-table:: lib_xua structure
+.. list-table:: ``lib_xua`` structure
 
  * - core
    - Common code for USB audio applications
@@ -22,7 +23,8 @@ The code is split into several directories.
  * - hid
    - Human Interface Device code
 
-Note, the midi and dfu directories are potential candidates for separate libs in their own right.
+Note, the ``midi`` and ``dfu`` directories are potential candidates for separate libs in their own
+right.
 
 Using in an application
 =======================
@@ -30,7 +32,8 @@ Using in an application
 ``lib_xua`` is intended to be used with `XCommon CMake <https://www.xmos.com/file/xcommon-cmake-documentation/?version=latest>`_
 , the `XMOS` application build and dependency management system.
 
-To use ``lib_xua`` in an application, add ``lib_xua``, to the list of dependent modules in the application's `CMakeLists.txt` file.
+To use ``lib_xua`` in an application, add ``lib_xua``, to the list of dependent modules in the
+application's `CMakeLists.txt` file.
 
   set(APP_DEPENDENT_MODULES "lib_xua")
 
@@ -43,8 +46,8 @@ All `lib_xua` functions can be accessed via the ``xua.h`` header file::
 "Codeless" programming model
 ============================
 
-Whilst it is possible to code a USB Audio device using the building blocks provided by `lib_xua`,
-it is realised that this might not be desirable for many classes of customers or products.
+While it is possible to build a USB Audio device from the low-level components provided by
+``lib_xua``, this approach may not be suitable for all customers or product types.
 
 For instance, some users may not have a large software development experience and simply want to
 customise some basic settings such as strings, sample-rates, channel-counts etc.
@@ -60,77 +63,30 @@ In order to cater for the former class of users, a "codeless" option is provided
 required hardware resource declarations. Code is generated based on the options provided by the
 developer in ``xua_conf.h``.
 
-Using this development model the user simply includes a ``xua_conf.h`` with their settings and
+Using this development model the user simply authors a ``xua_conf.h`` with their settings and
 optional implementations of any 'user functions' as desired. This, along with an XN file for their
 hardware platform, is all that is required to build a fully featured and functioning product. This
 XN file should contain definitions of the ports used for the various ``lib_xua`` functionality,
 see :ref:`sec_options`.
 
-This development model also provides the benefit of a full and verified codebase as a basis for a product.
+This development model also provides the benefit of a full and verified codebase as a basis for a
+product.
 
-This behaviour described in this section is the default behaviour of `lib_xua`, to disable this please
+This behaviour described in this section is the default behaviour of ``lib_xua``, to disable this
 set ``EXCLUDE_USB_AUDIO_MAIN`` to 1 in the application `CMakeLists.txt` or ``xua_conf.h`` and see
 :ref:`sec_advanced_usage`.
-
-
-Extending the "Codeless" application
-====================================
-
-The ``main.xc`` function allows insertion of extra code using the preprocessor. For example, you may wish
-to add some control code to control buttons or LEDs or DSP tasks for audio enhancement.
-
-Adding globals
-..............
-
-To add globals to your application, you may declare them in a dedicated source file in your project. They
-may then be referenced from other files using the ``extern`` keyword.
-
-Alternatively, you may add an optional header file to your project called ``user_main_globals.h``.
-If this file exists, its contents will be inserted into ``main.xc`` in global scope.
-
-Example contents of ``user_main_globals.h``::
-
-  unsigned my_global_var = 42;
-
-Adding main function declarations
-.................................
-
-To add declarations to your application, for example channels or interfaces to connect between tasks, you can
-define the token ``USER_MAIN_DECLARATIONS`` from your ``xua_conf.h`` configuration file. This inserts the 
-macro inside ``main.xc`` after ``main()`` but before the main ``par`` statement. 
-
-Alternatively, you may add an optional header file to your project called ``user_main_declarations.h``.
-If this file exists, its contents will be inserted into ``main.xc`` before the main ``par`` statement.
-
-Example contents of ``user_main_declarations.h``::
-
-  chan c_usb_to_user_interface;
-
-
-Adding main function tasks
-..........................
-
-To add extra tasks to your application, you can define the token ``USER_MAIN_CORES`` from your ``xua_conf.h`` configuration file. This inserts the  macro inside ``main.xc`` after the main ``par`` statement meaning the
-compiler will run these tasks in parallel, either on a dedicated hardware thread or combine with other tasks if the task is marked as ``[[combinable]]``. 
-                   
-Alternatively, you may add an optional header file to your project called ``user_main_cores.h``.
-If this file exists, its contents will be inserted into ``main.xc`` after the main ``par`` statement.
-
-Example contents of ``user_main_cores.h``::
-
-  on tile[1]: my_user_interface_task(c_usb_to_user_interface);
 
 Configuring lib_xua
 ===================
 
-Configuration of the various build time options of ``lib_xua`` is done via the optional header `xua_conf.h`.
-To allow the build scripts to locate this file it should reside somewhere in the application `src` directory.
+Configuration of the various build time options of ``lib_xua`` is done via the optional header ``xua_conf.h``.
+To allow the build system to locate this file it should reside somewhere in the application `src` directory.
 
-Such build time options include audio class version, sample rates, channel counts etc. Please see
+Such build time options include audio class version, sample rates, channel counts etc. See
 :ref:`sec_api` for full listings.
 
-The build system will automatically include the `xua_conf.h` header file as appropriate - the developer
-should continue to include `xua.h` as previously directed. A simple example `xua_conf.h` file is
+The build system will automatically include the ``xua_conf.h`` header file as appropriate - the developer
+should continue to include ``xua.h`` as previously directed. A simple example ``xua_conf.h`` file is
 shown below::
 
     #ifndef _XUA_CONF_H_
@@ -150,4 +106,63 @@ User functions
 To enable custom functionality, such as configuring external audio hardware, bespoke behaviour on
 stream start/stop etc, various functions can be overridden by the user. (see :ref:`sec_api` for
 full listings). The default implementations of these functions are empty.
+
+Extending the "Codeless" application
+====================================
+
+The ``main.xc`` function allows insertion of extra code using the preprocessor. For example, you
+may wish to add some control code to control buttons or LEDs or DSP tasks for audio enhancement.
+
+Adding Globals
+..............
+
+An optional header file named ``user_main_globals.h`` can be added to the project.
+
+If this file exists in the project's source tree, its contents will be inserted into
+``main.xc`` at global scope.
+
+Example contents of ``user_main_globals.h``::
+
+  unsigned my_global_var = 42;
+
+This file may also be used to include additional headers or declare function prototypes,
+for example::
+
+  #include "my_header.h"
+  void my_function(int x);
+
+This allows these functions and variables to be available for use in custom code
+inserted by the following two sections (e.g. user-defined tasks or initialisation).
+
+Adding main function declarations
+.................................
+
+To add declarations to the application - such as channels or interfaces for communication
+between tasks — the define ``USER_MAIN_DECLARATIONS``  can be set in the ``xua_conf.h``
+header file. This inserts code into ``main.xc`` after the ``main()`` definition
+but before the main ``par`` statement.
+
+Alternatively, an optional header file may be added to the project called
+``user_main_declarations.h``. If this file exists in the project's source tree, its
+contents will be inserted into ``main.xc`` before the main ``par`` statement.
+
+Example contents of ``user_main_declarations.h``::
+
+  chan c_usb_to_user_interface;
+
+Adding main function tasks
+..........................
+
+To add extra tasks to the application, the define ``USER_MAIN_TASKS`` can be set in the
+``xua_conf.h`` header file. This will insert code into ``main.xc`` after the main ``par``
+statement, allowing the compiler to run these tasks in parallel — either on a dedicated hardware
+thread or combined with other tasks if marked as ``[[combinable]]``.
+
+Alternatively, an optional header file called ``user_main_tasks.h`` can be added to project.
+If this file exists anywhere in the project source tree, its contents will be inserted into
+``main.xc`` after the main ``par`` statement.
+
+Example contents of ``user_main_tasks.h``::
+
+  on tile[1]: my_user_interface_task(c_usb_to_user_interface);
 

--- a/lib_xua/lib_build_info.cmake
+++ b/lib_xua/lib_build_info.cmake
@@ -26,7 +26,8 @@ set(LIB_OPTIONAL_HEADERS    xua_conf.h
                             static_hid_report.h
                             user_main_globals.h
                             user_main_declarations.h
-                            user_main_cores.h)
+                            user_main_cores.h
+                            user_main_tasks.h)
 
 set(LIB_DEPENDENT_MODULES "lib_adat(2.0.1)"
                           "lib_locks(2.3.1)"

--- a/lib_xua/module_build_info
+++ b/lib_xua/module_build_info
@@ -35,7 +35,7 @@ XCC_FLAGS_dfu.xc = $(MODULE_XCC_FLAGS) -Os -mno-dual-issue
 XCC_FLAGS_flash_interface.c = $(MODULE_XCC_FLAGS) -Os -mno-dual-issue
 XCC_FLAGS_flashlib_user.c = $(MODULE_XCC_FLAGS) -Os -mno-dual-issue
 
-OPTIONAL_HEADERS += xua_conf.h static_hid_report.h user_main_globals.h user_main_declarations.h user_main_cores.h
+OPTIONAL_HEADERS += xua_conf.h static_hid_report.h user_main_globals.h user_main_declarations.h user_main_cores.h user_main_tasks.h
 
 EXPORT_INCLUDE_DIRS = api \
                       src/core \

--- a/lib_xua/src/core/main.xc
+++ b/lib_xua/src/core/main.xc
@@ -382,6 +382,11 @@ void usb_audio_io(chanend ?c_aud_in,
     } // par
 }
 
+/* USER_MAIN_GLOBALS can be defined either via xua_conf.h or by user_main_globals.h */
+#ifdef __user_main_globals_h_exists__
+    #include "user_main_globals.h"
+#endif
+
 #ifndef USER_MAIN_GLOBALS
 #define USER_MAIN_GLOBALS
 #endif
@@ -394,12 +399,11 @@ void usb_audio_io(chanend ?c_aud_in,
 #define USER_MAIN_CORES
 #endif
 
-
-/* USER_MAIN_GLOBALS can be defined either via xua_conf.h or by user_main_globals.h */
-#ifdef __user_main_globals_h_exists__
-    #include "user_main_globals.h"
+#ifndef USER_MAIN_TASKS
+#define USER_MAIN_TASKS
 #endif
-        USER_MAIN_GLOBALS
+
+    USER_MAIN_GLOBALS
 
 /* Main for USB Audio Applications */
 int main()
@@ -483,11 +487,15 @@ int main()
     par
     {
 
-/* USER_MAIN_CORES can be defined either via xua_conf.h or by user_main_cores.h */
+/* USER_MAIN_CORES can be defined either via xua_conf.h or by user_main_tasks.h */
 #ifdef __user_main_cores_h_exists__
     #include "user_main_cores.h"
 #endif
+#ifdef __user_main_tasks_h_exists__
+    #include "user_main_tasks.h"
+#endif
         USER_MAIN_CORES
+        USER_MAIN_TASKS
 
 #if (((XUA_SYNCMODE == XUA_SYNCMODE_SYNC  && !XUA_USE_SW_PLL) || XUA_SPDIF_RX_EN || XUA_ADAT_RX_EN))
         on tile[PLL_REF_TILE]: PllRefPinTask(i_pll_ref, p_pll_ref);


### PR DESCRIPTION
-  Same functionality as USER_MAIN_CORES and user_main_cores.h but with updated terminology (could have gone with "threads" but this is extra safe ;) )
- Updated documentation to reflect changes 
- Moved the user_main_globals.h include before the default defines of USER_MAIN_GLOBALS etc so they can be defined in that file