### PR TITLE
Renamed user_main_* header optional header files to xua_conf_*

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,16 +4,20 @@ lib_xua change log
 UNRELEASED
 ----------
 
-  * ADDED: Support for optional include header `user_main_tasks.h` with the same
-    functionality as `user_main_cores.h` i.e. to allow insertion of tasks into
-    the `main()` function (`user_main_cores.h` to be deprecated in a future
+  * ADDED:     Support for optional include header `xua_conf_tasks.h` with the
+    same functionality as `xua_conf_cores.h` i.e. to allow insertion of tasks
+    into the `main()` function (`xua_conf_cores.h` to be deprecated in a future
     release)
-    ADDED: Support for define `USER_MAIN_TASKS` with the same functionalty as
-    `USER_MAIN_CORES` i.e. to allow insertion of tasks into the `main()`
+    ADDED:     Support for define `USER_MAIN_TASKS` with the same functionalty
+    as `USER_MAIN_CORES` i.e. to allow insertion of tasks into the `main()`
     function (`USER_MAIN_CORES` to be deprecated in a future release)
-  * FIXED: Issue with MCLK not present for digital RX only configs when using
+  * CHANGED:   Supported optional configuration header files
+    `user_main_cores.h`, `user_main_declarations.h` and `user_main_globasl.h`
+    should now be named `xua_conf_cores.h`, `xua_conf_declarations.h` and
+    `xua_conf_globals.h` respectively
+  * FIXED:     Issue with MCLK not present for digital RX only configs when using
     the software PLL
-  * FIXED: Reset SW PLL phase/frequency detector when digital clock becomes
+  * FIXED:     Reset SW PLL phase/frequency detector when digital clock becomes
     invalid to prevent incorrect error input to sigma-delta modulator
 
 5.1.0

--- a/doc/rst/using.rst
+++ b/doc/rst/using.rst
@@ -116,12 +116,12 @@ may wish to add some control code to control buttons or LEDs or DSP tasks for au
 Adding Globals
 ..............
 
-An optional header file named ``user_main_globals.h`` can be added to the project.
+An optional header file named ``xua_conf_globals.h`` can be added to the project.
 
 If this file exists in the project's source tree, its contents will be inserted into
 ``main.xc`` at global scope.
 
-Example contents of ``user_main_globals.h``::
+Example contents of ``xua_conf_globals.h``::
 
   unsigned my_global_var = 42;
 
@@ -143,10 +143,10 @@ header file. This inserts code into ``main.xc`` after the ``main()`` definition
 but before the main ``par`` statement.
 
 Alternatively, an optional header file may be added to the project called
-``user_main_declarations.h``. If this file exists in the project's source tree, its
+``xua_conf_declarations.h``. If this file exists in the project's source tree, its
 contents will be inserted into ``main.xc`` before the main ``par`` statement.
 
-Example contents of ``user_main_declarations.h``::
+Example contents of ``xua_conf_declarations.h``::
 
   chan c_usb_to_user_interface;
 
@@ -158,11 +158,11 @@ To add extra tasks to the application, the define ``USER_MAIN_TASKS`` can be set
 statement, allowing the compiler to run these tasks in parallel — either on a dedicated hardware
 thread or combined with other tasks if marked as ``[[combinable]]``.
 
-Alternatively, an optional header file called ``user_main_tasks.h`` can be added to project.
+Alternatively, an optional header file called ``xua_conf_tasks.h`` can be added to project.
 If this file exists anywhere in the project source tree, its contents will be inserted into
 ``main.xc`` after the main ``par`` statement.
 
-Example contents of ``user_main_tasks.h``::
+Example contents of ``xua_conf_tasks.h``::
 
   on tile[1]: my_user_interface_task(c_usb_to_user_interface);
 

--- a/lib_xua/lib_build_info.cmake
+++ b/lib_xua/lib_build_info.cmake
@@ -23,11 +23,12 @@ set(LIB_INCLUDES api
                  src/midi)
 
 set(LIB_OPTIONAL_HEADERS    xua_conf.h
+                            xua_conf_globals.h
+                            xua_conf_declarations.h
+                            xua_conf_cores.h
+                            xua_conf_tasks.h
                             static_hid_report.h
-                            user_main_globals.h
-                            user_main_declarations.h
-                            user_main_cores.h
-                            user_main_tasks.h)
+                            )
 
 set(LIB_DEPENDENT_MODULES "lib_adat(2.0.1)"
                           "lib_locks(2.3.1)"

--- a/lib_xua/module_build_info
+++ b/lib_xua/module_build_info
@@ -35,7 +35,7 @@ XCC_FLAGS_dfu.xc = $(MODULE_XCC_FLAGS) -Os -mno-dual-issue
 XCC_FLAGS_flash_interface.c = $(MODULE_XCC_FLAGS) -Os -mno-dual-issue
 XCC_FLAGS_flashlib_user.c = $(MODULE_XCC_FLAGS) -Os -mno-dual-issue
 
-OPTIONAL_HEADERS += xua_conf.h static_hid_report.h user_main_globals.h user_main_declarations.h user_main_cores.h user_main_tasks.h
+OPTIONAL_HEADERS += xua_conf.h xua_conf_globals.h xua_conf_declarations.h xua_conf_cores.h xua_conf_tasks.h static_hid_report.h
 
 EXPORT_INCLUDE_DIRS = api \
                       src/core \

--- a/lib_xua/src/core/main.xc
+++ b/lib_xua/src/core/main.xc
@@ -382,9 +382,9 @@ void usb_audio_io(chanend ?c_aud_in,
     } // par
 }
 
-/* USER_MAIN_GLOBALS can be defined either via xua_conf.h or by user_main_globals.h */
-#ifdef __user_main_globals_h_exists__
-    #include "user_main_globals.h"
+/* USER_MAIN_GLOBALS can be defined either via xua_conf.h or by xua_conf_globals.h */
+#ifdef __xua_conf_globals_h_exists__
+    #include "xua_conf_globals.h"
 #endif
 
 #ifndef USER_MAIN_GLOBALS
@@ -477,9 +477,9 @@ int main()
 #define c_mix_ctl null
 #endif
 
-/* USER_MAIN_DECLARATIONS can be defined either via xua_conf.h or by user_main_declarations.h */
-#ifdef __user_main_declarations_h_exists__
-    #include "user_main_declarations.h"
+/* USER_MAIN_DECLARATIONS can be defined either via xua_conf.h or by xua_conf_declarations.h */
+#ifdef __xua_conf_declarations_h_exists__
+    #include "xua_conf_declarations.h"
 #endif
 
     USER_MAIN_DECLARATIONS
@@ -487,12 +487,12 @@ int main()
     par
     {
 
-/* USER_MAIN_CORES can be defined either via xua_conf.h or by user_main_tasks.h */
-#ifdef __user_main_cores_h_exists__
-    #include "user_main_cores.h"
+/* USER_MAIN_CORES can be defined either via xua_conf.h or by xua_conf_tasks.h */
+#ifdef __xua_conf_cores_h_exists__
+    #include "xua_conf_cores.h"
 #endif
-#ifdef __user_main_tasks_h_exists__
-    #include "user_main_tasks.h"
+#ifdef __xua_conf_tasks_h_exists__
+    #include "xua_conf_tasks.h"
 #endif
         USER_MAIN_CORES
         USER_MAIN_TASKS


### PR DESCRIPTION
Seems like a sensible change. Fits in the _conf_ naming scheme and has some kind name space (user_main_ was pretty generic)

Updated docs inline. 