### PR TITLE
Move test deps clone from jenkinsfile to tests/requirements.txt

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,19 +2,6 @@
 
 @Library('xmos_jenkins_shared_library@v0.39.0') _
 
-def clone_test_deps() {
-  dir("${WORKSPACE}") {
-    sh "git clone git@github.com:xmos/test_support"
-    sh "git -C test_support checkout 961532d89a98b9df9ccbce5abd0d07d176ceda40"
-
-    sh "git clone git@github0.xmos.com:xmos-int/xtagctl"
-    sh "git -C xtagctl checkout v2.0.0"
-
-    sh "git clone git@github.com:xmos/hardware_test_tools"
-    sh "git -C hardware_test_tools checkout develop"
-  }
-}
-
 getApproval()
 
 pipeline {
@@ -44,8 +31,9 @@ pipeline {
       defaultValue: 'v2.1.0',
       description: 'The infr_apps version'
     )
-    choice(name: 'TEST_LEVEL', choices: ['smoke', 'nightly'],
-            description: 'The level of test coverage to run')
+    choice(
+        name: 'TEST_LEVEL', choices: ['smoke', 'nightly'],
+        description: 'The level of test coverage to run')
   }
 
   stages {
@@ -300,8 +288,6 @@ pipeline {
             dir("${REPO}") {
               checkoutScmShallow()
 
-              clone_test_deps()
-
               withTools(params.TOOLS_VERSION) {
                 dir("tests") {
                   createVenv(reqFile: "requirements.txt")
@@ -344,8 +330,6 @@ pipeline {
           }
           steps {
             println "Stage running on ${env.NODE_NAME}"
-
-            clone_test_deps()
 
             dir("${REPO}") {
               checkoutScmShallow()
@@ -390,8 +374,6 @@ pipeline {
           }
           steps {
             println "Stage running on ${env.NODE_NAME}"
-
-            clone_test_deps()
 
             dir("${REPO}") {
               checkoutScmShallow()

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -35,6 +35,7 @@ pyyaml==6.0.2
 # If this repository uses the setup functionality (e.g., script entry points)
 # of its own setup.py file, then this list must include an entry for that
 # setup.py file, e.g., '-e .' or '-e ./python' (without the quotes).
--e ./../../test_support
--e ./../../hardware_test_tools
--e ./../../xtagctl
+-e git+ssh://git@github.com/xmos/test_support.git@961532d89a98b9df9ccbce5abd0d07d176ceda40#egg=test_support
+-e git+ssh://git@github.com/xmos/hardware_test_tools.git@984b1e1176003fd55be08001db27aeb58f7a10c9#egg=hardware_test_tools
+-e git+ssh://git@github0.xmos.com/xmos-int/xtagctl.git@v2.0.0#egg=xtagctl
+


### PR DESCRIPTION
Move cloning of deps required for testing from Jenkinsfile to tests/requirements.txt.

Makes it easer to setup and run tests locally. I think, in general, this is a nicer pattern than adding manual clones to Jenkinsfile. 
 