### PR TITLE
Added XUA_DESC_INPUT_TYPE_LINE_IN to have input channels show up as l…

### DIFF
--- a/lib_xua/api/xua_conf_default.h
+++ b/lib_xua/api/xua_conf_default.h
@@ -364,6 +364,17 @@
     #endif
 #endif
 
+/** @brief Input channel terminal type override to line in
+ * 
+ * Set to 1 to have USB input present as line-in to the host
+ * 
+ * Default: disabled (input channels appear as mics)
+ *
+ */
+#ifndef XUA_DEC_INPUT_TYPE_LINE_IN
+    #define XUA_DEC_INPUT_TYPE_LINE_IN (0)
+#endif
+
 /*
  * Feature defines
  */

--- a/lib_xua/src/core/endpoint0/xua_ep0_descriptors.h
+++ b/lib_xua/src/core/endpoint0/xua_ep0_descriptors.h
@@ -1155,7 +1155,11 @@ USB_Config_Descriptor_Audio2_t cfgDesc_Audio2=
             .bDescriptorType           = UAC_CS_DESCTYPE_INTERFACE,
             .bDescriptorSubtype        = UAC_CS_AC_INTERFACE_SUBTYPE_INPUT_TERMINAL,
             .bTerminalID               = ID_IT_AUD,
+#ifdef XUA_DESC_INPUT_TYPE_LINE_IN
+            .wTerminalType             = UAC_TT_EXTERNAL_TERMTYPE_LINE_CONNECTOR,            
+#else            
             .wTerminalType             = UAC_TT_INPUT_TERMTYPE_MICROPHONE,
+#endif //
             .bAssocTerminal            = 0x00,
             .bCSourceID                = ID_CLKSEL,
             .bNrChannels               = NUM_USB_CHAN_IN,

--- a/lib_xua/src/core/endpoint0/xua_ep0_descriptors.h
+++ b/lib_xua/src/core/endpoint0/xua_ep0_descriptors.h
@@ -1155,7 +1155,7 @@ USB_Config_Descriptor_Audio2_t cfgDesc_Audio2=
             .bDescriptorType           = UAC_CS_DESCTYPE_INTERFACE,
             .bDescriptorSubtype        = UAC_CS_AC_INTERFACE_SUBTYPE_INPUT_TERMINAL,
             .bTerminalID               = ID_IT_AUD,
-#ifdef XUA_DESC_INPUT_TYPE_LINE_IN
+#if XUA_DESC_INPUT_TYPE_LINE_IN
             .wTerminalType             = UAC_TT_EXTERNAL_TERMTYPE_LINE_CONNECTOR,            
 #else            
             .wTerminalType             = UAC_TT_INPUT_TERMTYPE_MICROPHONE,


### PR DESCRIPTION
…ine inputs rather than mics. Backwards compatible change.

Note this depends on https://github.com/xmos/lib_xud/pull/464 and should resolve https://github.com/xmos/lib_xua/issues/281 though it does not address a case where different channels are of different types.