### PR TITLE
Derive TILE defines from PORT defines

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,27 +4,37 @@ lib_xua change log
 UNRELEASED
 ----------
 
-  * ADDED:     Support for optional include header `xua_conf_tasks.h` with the
-    same functionality as `xua_conf_cores.h` i.e. to allow insertion of tasks
-    into the `main()` function (`xua_conf_cores.h` to be deprecated in a future
-    release)
-    ADDED:     Support for define `USER_MAIN_TASKS` with the same functionalty
-    as `USER_MAIN_CORES` i.e. to allow insertion of tasks into the `main()`
-    function (`USER_MAIN_CORES` to be deprecated in a future release)
+  * ADDED:     Support for optional include header ``xua_conf_tasks.h`` with the
+    same functionality as ``xua_conf_cores.h`` i.e. to allow insertion of tasks
+    into the ``main()`` function (``xua_conf_cores.h`` to be deprecated in a
+    future release)
+    ADDED:     Support for define ``USER_MAIN_TASKS`` with the same functionalty
+    as ``USER_MAIN_CORES`` i.e. to allow insertion of tasks into the `main()`
+    function (``USER_MAIN_CORES`` to be deprecated in a future release)
+  * ADDED:     Support for high bandwidth ISO endpoints
+  * ADDED:     Delay in ``AudioHub()`` to allow time for the audio PLL to  lock
+    and master clock stabilise
+  * ADDED:     Change to reset `Software` PLL DCO setting to midpoint when there's
+    a change in clock source
+  * ADDED:     Where possible ``_TILE_NUM`` defines are now derived from
+    ``PORT_`` defines in the application XN file
+  * CHANGED:   When `Software PLL` is enabled, report external clock as invalid
+    when the USB sampling frequency doesn't match the digital input sampling
+    frequency
+  * CHANGED:   ``AUDIO_IO_TILE`` renamed to ``XUA_AUDIO_IO_TILE_NUM``
+  * CHANGED:   ``XUA_TILE`` renamed to ``XUA_XUD_TILE_NUM``
+  * CHANGED:   ``MIDI_TILE`` renamed to ``XUA_MIDI_TILE_NUM``
+  * CHANGED:   ``SPDIF_TX_TILE`` renamed to ``XUA_SPDIF_TX_TILE_NUM``
+  * CHANGED:   ``PDM_TILE`` renamed to ``XUA_MIC_PDM_TILE_NUM``
+  * CHANGED:   ``PLL_REF_TILE`` renamed to ``XUA_PLL_REF_TILE_NUM``
   * CHANGED:   Supported optional configuration header files
-    `user_main_cores.h`, `user_main_declarations.h` and `user_main_globasl.h`
-    should now be named `xua_conf_cores.h`, `xua_conf_declarations.h` and
-    `xua_conf_globals.h` respectively
-  * FIXED:     Issue with MCLK not present for digital RX only configs when using
-    the software PLL
-  * FIXED:     Reset SW PLL phase/frequency detector when digital clock becomes
-    invalid to prevent incorrect error input to sigma-delta modulator
-  * ADDED: Support for high bandwidth ISO endpoints
-  * ADDED: pll lock delay in audiohub to allow time for the audio pll to lock and MCLK to stabilise
-  * ADDED: Change to reset sw_pll dco setting to midpoint when there's a change in clock source
-  * FIXED: When software pll is enabled, report external clock as invalid when the USB sampling frequency
-    doesn't match the digital input sampling frequency, instead of programming a wrong value dco Setting
-    in the pll sigma delta modulator
+    ``user_main_cores.h``, ``user_main_declarations.h`` and
+    ``user_main_globals.h`` should now be named ``xua_conf_cores.h``,
+    ``xua_conf_declarations.h`` and ``xua_conf_globals.h`` respectively
+  * FIXED:     Issue with master clock not present for digital receive (only)
+    configs when using the `Software PLL`
+  * FIXED:     Reset `Software PLL` phase/frequency detector when digital clock
+    becomes invalid to prevent incorrect error input to sigma-delta modulator
 
 5.1.0
 -----

--- a/doc/rst/api_defines.rst
+++ b/doc/rst/api_defines.rst
@@ -15,12 +15,12 @@ This section fully documents all of the settable defines and their default value
 Code location (tile)
 --------------------
 
-.. doxygendefine:: AUDIO_IO_TILE
-.. doxygendefine:: XUD_TILE
-.. doxygendefine:: MIDI_TILE
-.. doxygendefine:: SPDIF_TX_TILE
-.. doxygendefine:: PDM_TILE
-.. doxygendefine:: PLL_REF_TILE
+.. doxygendefine:: XUA_AUDIO_IO_TILE_NUM
+.. doxygendefine:: XUA_XUD_TILE_NUM
+.. doxygendefine:: XUA_MIDI_TILE_NUM
+.. doxygendefine:: XUA_SPDIF_TX_TILE_NUM
+.. doxygendefine:: XUA_MIC_PDM_TILE_NUM
+.. doxygendefine:: XUA_PLL_REF_TILE_NUM
 
 Channel counts
 --------------

--- a/doc/rst/feat_adat_tx.rst
+++ b/doc/rst/feat_adat_tx.rst
@@ -64,7 +64,7 @@ The channel used for communicating between ``XUA_AudioHub`` and ADAT transmitter
 
 In order to use the ADAT transmitter with ``lib_xua`` a 1-bit port must be declared e.g::
 
-    on stdcore[AUDIO_IO_TILE] : buffered out port:32 p_adat_tx  = PORT_ADAT_OUT;
+    on tile[XUA_AUDIO_IO_TILE_NUM] : buffered out port:32 p_adat_tx  = PORT_ADAT_OUT;
 
 This port should be clocked from the master-clock::
 

--- a/doc/rst/opt_adat_rx.rst
+++ b/doc/rst/opt_adat_rx.rst
@@ -55,9 +55,9 @@ The programmer should ensure the defines in :numref:`opt_adat_rx_ref_defines` ar
    * - Define
      - Description
      - Default
-   * - ``PLL_REF_TILE``
+   * - ``XUA_PLL_REF_TILE_NUM``
      - Tile location of reference signal to CS2100 device
-     - ``AUDIO_IO_TILE``
+     - Derived from location of ``PORT_PLL_REF`` in XN file
 
 |endfullwidth|
 

--- a/doc/rst/opt_location.rst
+++ b/doc/rst/opt_location.rst
@@ -8,8 +8,13 @@ In a multi-tile system the codebase needs to be informed as to which tiles to us
 resources and associated code.
 
 A series of defines are used to allow the programmer to easily move code between tiles. Arguably the
-most important of these are ``AUDIO_IO_TILE`` and ``XUD_TILE``. :numref:`opt_location_defines` shows a
-full listing of these ``TILE`` defines.
+most important of these are ``XUA_AUDIO_IO_TILE_NUM`` and ``XUA_XUD_TILE_NUM``.
+:numref:`opt_location_defines` shows a full listing of these ``TILE`` defines.
+
+.. note::
+
+    If not explicitly defined by user, tile numbers will be derived from the application XN file
+    ``PORT`` defines. In general this is the recommended approach.
 
 .. tabularcolumns:: lp{5cm}l
 .. _opt_location_defines:
@@ -20,25 +25,26 @@ full listing of these ``TILE`` defines.
    * - Define
      - Description
      - Default
-   * - ``AUDIO_IO_TILE``
+   * - ``XUA_AUDIO_IO_TILE_NUM``
      - Tile on which I2S/TDM, ADAT Rx, S/PDIF Rx & mixer resides
-     - ``0``
-   * - ``XUD_TILE``
+     - Derived from related port defines in the application XN file
+   * - ``XUA_XUD_TILE_NUM``
      - Tile on which USB resides, including buffering for all USB interfaces/endppoints
      - ``0``
-   * - ``MIDI_TILE``
+   * - ``XUA_MIDI_TILE_NUM``
      - Tile on which MIDI resides
-     - Same as ``AUDIO_IO_TILE``
-   * - ``SPDIF_TX_TILE``
+     - Derived from MIDI related port defines in the application XN file
+   * - ``XUA_SPDIF_TX_TILE_NUM``
      - Tile on which S/PDIF Tx resides
-     - Same as ``AUDIO_IO_TILE``
-   * - ``PDM_TILE``
+     - Derived from PORT_SPDIF_OUT port define in the application XN file
+   * - ``XUA_MIC_PDM_TILE_NUM``
      - Tile on which PDM microphones resides
-     - Same as ``AUDIO_IO_TILE``
-   * - ``PLL_REF_TILE``
+     - Derived from Mic related port defines in the application XN file
+   * - ``XUA_PLL_REF_TILE_NUM``
      - Tile on which reference signal to CS2100 resides
-     - Same as ``AUDIO_IO_TILE``
+     - Derived from PORT_PLL_REF port define in the application XN file
 
 .. note::
 
-    It should be ensured that the relevant port defines in the application XN file match the code location defines
+    It should be ensured that the relevant port defines in the application XN file match the code
+    location defines

--- a/doc/rst/opt_mixer.rst
+++ b/doc/rst/opt_mixer.rst
@@ -36,6 +36,6 @@ Basic configuration of mixer functionality is achieved with the the defines
 
 .. note::
 
-   The mixer threads always run on the tile defined by ``AUDIO_IO_TILE``
+   The mixer threads always run on the tile defined by ``XUA_AUDIO_IO_TILE_NUM``
 
 

--- a/doc/rst/opt_spdif_rx.rst
+++ b/doc/rst/opt_spdif_rx.rst
@@ -26,7 +26,7 @@ Basic configuration of S/PDIF receive functionality is achieved with the defines
 
 .. note::
 
-   S/PDIF receive always runs on the tile defined by ``AUDIO_IO_TILE``
+   S/PDIF receive always runs on the tile defined by ``XUA_AUDIO_IO_TILE_NUM``
 
 The codebase expects the S/PDIF receive port to be defined in the application XN file as ``PORT_SPDIF_IN``.
 This must be a 1-bit port, for example::
@@ -46,9 +46,9 @@ The programmer should ensure the defines in :numref:`opt_spdif_rx_ref_defines` a
    * - Define
      - Description
      - Default
-   * - ``PLL_REF_TILE``
+   * - ``XUA_PLL_REF_TILE_NUM``
      - Tile location of reference to CS2100 device
-     - ``AUDIO_IO_TILE``
+     - Derived from ``PORT_PLL_REF`` in XN file
 
 The codebase expects this reference signal port to be defined in the application XN file as ``PORT_PLL_REF``.
 This may be a port of any bit-width, however, connection to bit[0] is assumed::

--- a/doc/rst/opt_spdif_tx.rst
+++ b/doc/rst/opt_spdif_tx.rst
@@ -36,9 +36,9 @@ In addition, the developer may choose which tile the S/PDIF transmitter runs on,
    * - Define
      - Description
      - Default
-   * - ``SPDIF_TX_TILE``
+   * - ``XUA_SPDIF_TX_TILE_NUM``
      - Tile that S/PDIF tx is connected to
-     - ``AUDIO_IO_TILE``
+     - Derived from PORT_SPDIF_OUT define in the application XN file
 
 The codebase expects the S/PDIF transmit port to be defined in the application XN file as ``PORT_SPDIF_OUT``.
 This must be a 1-bit port, for example::

--- a/doc/rst/opt_sync.rst
+++ b/doc/rst/opt_sync.rst
@@ -57,16 +57,16 @@ The programmer should ensure the defines in  :numref:`opt_sync_ref_defines` are 
    * - Define
      - Description
      - Default
-   * - ``PLL_REF_TILE``
+   * - ``XUA_PLL_REF_TILE_NUM``
      - Tile location of reference to CS2100 device
-     - ``AUDIO_IO_TILE``
+     - Dervied from PORT_PLL_REF in the application XN file.
    * - ``XUA_USE_SW_PLL``
      - Whether or not to use sw_pll to recover the clock (`xcore.ai` only)
      - 1 (enabled) for `xcore.ai` targets.
 
 
-The codebase expects the CS2100 reference signal port to be defined in the application XN file as ``PORT_PLL_REF``.
-This may be a port of any bit-width, however, connection to bit[0] is assumed::
+The codebase expects the CS2100 reference signal port to be defined in the application XN file as
+``PORT_PLL_REF``. This may be a port of any bit-width, however, connection to bit[0] is assumed::
 
     <Port Location="XS1_PORT_1A"  Name="PORT_PLL_REF"/>
 

--- a/examples/AN00248_xua_example_pdm_mics/src/xua_conf.h
+++ b/examples/AN00248_xua_example_pdm_mics/src/xua_conf.h
@@ -16,18 +16,21 @@
 #define MIN_FREQ                            XUA_PDM_MIC_FREQ /* Minimum sample rate */
 #define MAX_FREQ                            XUA_PDM_MIC_FREQ /* Maximum sample rate */
 
-#define AUDIO_IO_TILE 						1
+
 #define PORT_MCLK_IN_USB 					XS1_PORT_1D
 #define PORT_MCLK_COUNT 					XS1_PORT_16B
 #define PORT_I2S_DAC0						PORT_I2S_DAC_DATA
+
+/* Since the PORT defines are done manually above, not in the XN file, lib_xua must be told
+ * which tiles the ports are located */
+#define XUA_AUDIO_IO_TILE_NUM               1
 
 #define XUA_NUM_PDM_MICS                    2
 #define MIC_ARRAY_CONFIG_PORT_MCLK          PORT_MCLK_IN
 #define MIC_ARRAY_CONFIG_PORT_PDM_CLK       PORT_PDM_CLK
 #define MIC_ARRAY_CONFIG_PORT_PDM_DATA      PORT_PDM_DATA
-#define MIC_ARRAY_CONFIG_CLOCK_BLOCK_A      XS1_CLKBLK_1      
+#define MIC_ARRAY_CONFIG_CLOCK_BLOCK_A      XS1_CLKBLK_1
 #define MIC_ARRAY_CONFIG_CLOCK_BLOCK_B      XS1_CLKBLK_2    /* Second clock needed as we use DDR */
-#define PDM_TILE 							1
 
 #define AUDIO_CLASS                         1
 #define VENDOR_STR                          "XMOS"

--- a/lib_xua/api/xua_conf_default.h
+++ b/lib_xua/api/xua_conf_default.h
@@ -3,8 +3,8 @@
 /*
  * @brief       Defines relating to device configuration and customisation of lib_xua
  */
-#ifndef _XUA_CONF_DEFAULT_H_
-#define _XUA_CONF_DEFAULT_H_
+#ifndef XUA_CONF_DEFAULT_H_
+#define XUA_CONF_DEFAULT_H_
 
 #ifdef __xua_conf_h_exists__
     #include "xua_conf.h"
@@ -14,47 +14,121 @@
  * Tile arrangement defines
  */
 
-/**
- * @brief Location (tile) of audio I/O. Default: 0
- */
-#ifndef AUDIO_IO_TILE
-#define AUDIO_IO_TILE   (0)
+/* Tidy up legacy defines */
+#ifdef AUDIO_IO_TILE
+#define XUA_AUDIO_IO_TILE_NUM AUDIO_IO_TILE
+#endif
+
+#ifdef XUD_TILE
+#define XUA_XUD_TILE_NUM XUD_TILE
+#endif
+
+#ifdef MIDI_TILE
+#define XUA_MIDI_TILE_NUM MIDI_TILE
+#endif
+
+#ifdef SPDIF_TX_TILE
+#define XUA_SPDIF_TX_TILE_NUM SPDIF_TX_TILE
+#endif
+
+#ifdef PDM_TILE
+#define XUA_MIC_PDM_TILE_NUM PDM_TILE
+#endif
+
+#ifdef PLL_REF_TILE
+#define XUA_PLL_REF_TILE_NUM PLL_REF_TILE
 #endif
 
 /**
- * @brief Location (tile) of audio I/O. Default: 0
+ * @brief Location (tile) of audio I/O.
+ *
+ * The tile number to run the AudioHub() task.
+ * The location if automatically detected from ports in the XN file.
  */
-#ifndef XUD_TILE
-#define XUD_TILE        (0)
+#ifndef XUA_AUDIO_IO_TILE_NUM
+    #ifdef PORT_I2S_DAC0_TILE_NUM
+        #define XUA_AUDIO_IO_TILE_NUM   (PORT_I2S_DAC0_TILE_NUM)
+    #elif defined(PORT_I2S_ADC0_TILE_NUM)
+        #define XUA_AUDIO_IO_TILE_NUM   (PORT_I2S_ADC0_TILE_NUM)
+    #elif defined(PORT_I2S_BCLK_TILE_NUM)
+        #define XUA_AUDIO_IO_TILE_NUM   (PORT_I2S_BCLK_TILE_NUM)
+    #else
+        /* If cannot automatically detect, default to tile 0 */
+        #define XUA_AUDIO_IO_TILE_NUM   (0)
+    #endif
 #endif
 
 /**
- * @brief Location (tile) of MIDI I/O. Default: AUDIO_IO_TILE
+ * @brief Location (tile) of audio I/O.
+ *
+ * The tile number to run lib_xud tasks on.
  */
-#ifndef MIDI_TILE
-#define MIDI_TILE       AUDIO_IO_TILE
+#ifndef XUA_XUD_TILE_NUM
+#define XUA_XUD_TILE_NUM        (0)
 #endif
 
 /**
- * @brief Location (tile) of SPDIF Tx. Default: AUDIO_IO_TILE
+ * @brief Location (tile) of MIDI I/O.
+ *
+ * The tile number to run MIDI tasks on.
+ * The location if automatically detected from ports in the XN file.
  */
-#ifndef SPDIF_TX_TILE
-#define SPDIF_TX_TILE   AUDIO_IO_TILE
+#ifndef XUA_MIDI_TILE_NUM
+    #ifdef PORT_MIDI_IN_TILE
+        #define XUA_MIDI_TILE_NUM (PORT_MIDI_IN_TILE)
+    #elif defined(PORT_MIDI_OUT_TILE)
+        #define XUA_MIDI_TILE_NUM (PORT_MIDI_OUT_TILE)
+    #else
+        /* If cannot automatically detect, default to XUA_AUDIO_IO_TILE_NUM */
+        #define XUA_MIDI_TILE_NUM   XUA_AUDIO_IO_TILE_NUM
+    #endif
 #endif
 
 /**
- * @brief Location (tile) of PDM Rx. Default: AUDIO_IO_TILE
+ * @brief Location (tile) of SPDIF Tx.
+ *
+ * The tile number to run the S/PDIF tx task on.
+ * The location if automatically detected from ports in the XN file.
  */
-#ifndef PDM_TILE
-#define PDM_TILE        AUDIO_IO_TILE
+#ifndef XUA_SPDIF_TX_TILE_NUM
+    #ifdef PORT_SPDIF_TX_TILE
+        #define XUA_SPDIF_TX_TILE_NUM (PORT_SPDIF_TX_TILE)
+    #else
+        /* If cannot automatically detect, default to XUA_AUDIO_IO_TILE_NUM */
+        #define XUA_SPDIF_TX_TILE_NUM     XUA_AUDIO_IO_TILE_NUM
+    #endif
 #endif
 
 /**
- * @brief Location (tile) of reference signal to CS2100. Default: AUDIO_IO_TILE
+ * @brief Location (tile) of PDM Rx.
+ *
+ * The tile number to run the PDM Mics tasks on.
+ * The location if automatically detected from ports in the XN file.
  */
-#ifndef PLL_REF_TILE
-#define PLL_REF_TILE    AUDIO_IO_TILE
+#ifndef XUA_MIC_PDM_TILE_NUM
+    #ifdef PORT_PDM_CLK_TILE_NUM
+        #define XUA_MIC_PDM_TILE_NUM     PORT_PDM_CLK_TILE_NUM
+    #else
+        /* If cannot automatically detect, default to XUA_AUDIO_IO_TILE_NUM */
+        #define XUA_MIC_PDM_TILE_NUM     XUA_AUDIO_IO_TILE_NUM
+    #endif
 #endif
+
+/**
+ * @brief Location (tile) of reference signal to CS2100.
+ *
+ * The tile number to run the PLL reference clock task on.
+ * The location if automatically detected from ports in the XN file.
+ */
+#ifndef XUA_PLL_REF_TILE_NUM
+    #ifdef PORT_PLL_REF_TILE_NUM
+        #define XUA_PLL_REF_TILE_NUM   PORT_PLL_REF_TILE_NUM
+    #else
+        /* If cannot automatically detect, default to XUA_AUDIO_IO_TILE_NUM */
+        #define XUA_PLL_REF_TILE_NUM   XUA_AUDIO_IO_TILE_NUM
+    #endif
+#endif
+
 
 /*
  * Audio channel based defines
@@ -385,13 +459,6 @@
  * */
 #ifndef PDM_MIC_INDEX
 #define PDM_MIC_INDEX           (0)
-#endif
-
-/**
- * @brief Size of a frame of microphone data samples. Default: 1
- */
-#ifndef XUA_MIC_FRAME_SIZE
-#define XUA_MIC_FRAME_SIZE      (1)
 #endif
 
 /**
@@ -1746,16 +1813,16 @@ enum USBEndpointNumber_Out
     (_NEED_MCLK_FOR_I2S) || \
     (_NEED_MCLK_FOR_DIG_RX) || \
     (_NEED_MCLK_FOR_ADAT_TX) || \
-    (_NEED_MCLK_FOR_SPDIF_TX && (SPDIF_TX_TILE == AUDIO_IO_TILE)) || \
-    (_NEED_MCLK_FOR_USB && (AUDIO_IO_TILE == XUD_TILE)) \
+    (_NEED_MCLK_FOR_SPDIF_TX && (SPDIF_TX_TILE == XUA_AUDIO_IO_TILE_NUM)) || \
+    (_NEED_MCLK_FOR_USB && (XUA_AUDIO_IO_TILE_NUM == XUA_XUD_TILE_NUM)) \
 )
 
 /* Need second mclk -
  - USB is enabled and present on a different tile than audio, a second mclk will be needed for USB feedback calculation
  - SPDIF TX is enabled and present on a different tile than audio */
 #define SECOND_MCLK_REQUIRED ( \
-    (_NEED_MCLK_FOR_USB && (XUD_TILE != AUDIO_IO_TILE)) || \
-    (_NEED_MCLK_FOR_SPDIF_TX && (SPDIF_TX_TILE != AUDIO_IO_TILE)) \
+    (_NEED_MCLK_FOR_USB && (XUA_XUD_TILE_NUM != XUA_AUDIO_IO_TILE_NUM)) || \
+    (_NEED_MCLK_FOR_SPDIF_TX && (XUA_SPDIF_TX_TILE_NUM != XUA_AUDIO_IO_TILE_NUM)) \
 )
 
 #endif /* _XUA_CONF_DEFAULT_H_ */

--- a/lib_xua/src/core/audiohub/xua_audiohub.xc
+++ b/lib_xua/src/core/audiohub/xua_audiohub.xc
@@ -687,7 +687,7 @@ void check_and_enter_dfu(unsigned curSamFreq, chanend c_aud, server interface i_
            [[combine]]
             par
             {
-#if (XUD_TILE != 0) && (AUDIO_IO_TILE == 0)
+#if (XUA_XUD_TILE_NUM != 0) && (XUA_AUDIO_IO_TILE_NUM == 0)
                 DFUHandler(dfuInterface, null);
 #endif
                 /* This never exits because we set DFU mode*/
@@ -715,7 +715,7 @@ void XUA_AudioHub(chanend ?c_aud, clock ?clk_audio_mclk, clock ?clk_audio_bclk,
 #if (XUA_SYNCMODE == XUA_SYNCMODE_SYNC || XUA_SPDIF_RX_EN || XUA_ADAT_RX_EN)
     , chanend c_audio_rate_change
 #endif
-#if (XUD_TILE != 0) && (AUDIO_IO_TILE == 0) && (XUA_DFU_EN == 1)
+#if (XUA_XUD_TILE_NUM != 0) && (XUA_AUDIO_IO_TILE_NUM == 0) && (XUA_DFU_EN == 1)
     , server interface i_dfu ?dfuInterface
 #endif
 #if (XUA_NUM_PDM_MICS > 0)
@@ -724,7 +724,7 @@ void XUA_AudioHub(chanend ?c_aud, clock ?clk_audio_mclk, clock ?clk_audio_bclk,
 )
 {
 /* This is a bit annoying but we have a mixture of nullable interfaces and variadic function signatures based on defines */
-#if !((XUD_TILE != 0) && (AUDIO_IO_TILE == 0) && (XUA_DFU_EN == 1))
+#if !((XUA_XUD_TILE_NUM != 0) && (XUA_AUDIO_IO_TILE_NUM == 0) && (XUA_DFU_EN == 1))
 #define dfuInterface null
 #endif
 #if (XUA_ADAT_TX_EN)
@@ -783,7 +783,7 @@ void XUA_AudioHub(chanend ?c_aud, clock ?clk_audio_mclk, clock ?clk_audio_bclk,
 #endif
 
 #if (MCLK_REQUIRED)
-        xassert((!isnull(clk_audio_mclk) && !isnull(p_mclk_in)) && "Error: must provide non-null MCLK port and MCLK clock-block if digital Rx is enabled or AUDIO_IO_TILE==XUD_TILE");
+        xassert((!isnull(clk_audio_mclk) && !isnull(p_mclk_in)) && "Error: must provide non-null MCLK port and MCLK clock-block if digital Rx is enabled or XUA_AUDIO_IO_TILE_NUM==XUA_XUD_TILE_NUM");
         /* Clock master clock-block from master-clock port */
         configure_clock_src(clk_audio_mclk, p_mclk_in);
 #if (XUA_ADAT_TX_EN)

--- a/lib_xua/src/core/main.xc
+++ b/lib_xua/src/core/main.xc
@@ -44,7 +44,7 @@ void DFUHandler(server interface i_dfu i, chanend ?c_user_cmd);
 
 /* Audio I/O - Port declarations */
 #if I2S_WIRES_DAC > 0
-on tile[AUDIO_IO_TILE] : buffered out port:32 p_i2s_dac[I2S_WIRES_DAC] =
+on tile[XUA_AUDIO_IO_TILE_NUM] : buffered out port:32 p_i2s_dac[I2S_WIRES_DAC] =
                 {PORT_I2S_DAC0,
 #endif
 #if I2S_WIRES_DAC > 1
@@ -75,7 +75,7 @@ on tile[AUDIO_IO_TILE] : buffered out port:32 p_i2s_dac[I2S_WIRES_DAC] =
 #endif
 
 #if I2S_WIRES_ADC > 0
-on tile[AUDIO_IO_TILE] : buffered in port:32 p_i2s_adc[I2S_WIRES_ADC] =
+on tile[XUA_AUDIO_IO_TILE_NUM] : buffered in port:32 p_i2s_adc[I2S_WIRES_ADC] =
                 {PORT_I2S_ADC0,
 #endif
 #if I2S_WIRES_ADC > 1
@@ -107,16 +107,16 @@ on tile[AUDIO_IO_TILE] : buffered in port:32 p_i2s_adc[I2S_WIRES_ADC] =
 
 
 #if CODEC_MASTER
-on tile[AUDIO_IO_TILE] : buffered in port:32 p_lrclk        = PORT_I2S_LRCLK;
-on tile[AUDIO_IO_TILE] : buffered in port:32 p_bclk         = PORT_I2S_BCLK;
+on tile[XUA_AUDIO_IO_TILE_NUM] : buffered in port:32 p_lrclk        = PORT_I2S_LRCLK;
+on tile[XUA_AUDIO_IO_TILE_NUM] : buffered in port:32 p_bclk         = PORT_I2S_BCLK;
 #else
-on tile[AUDIO_IO_TILE] : buffered out port:32 p_lrclk       = PORT_I2S_LRCLK;
-on tile[AUDIO_IO_TILE] : buffered out port:32 p_bclk        = PORT_I2S_BCLK;
+on tile[XUA_AUDIO_IO_TILE_NUM] : buffered out port:32 p_lrclk       = PORT_I2S_LRCLK;
+on tile[XUA_AUDIO_IO_TILE_NUM] : buffered out port:32 p_bclk        = PORT_I2S_BCLK;
 #endif
 
 #if (MCLK_REQUIRED)
 /* Audio master clock input */
-on tile[AUDIO_IO_TILE] :  in port p_mclk_in                 = PORT_MCLK_IN;
+on tile[XUA_AUDIO_IO_TILE_NUM] :  in port p_mclk_in                 = PORT_MCLK_IN;
 #else
 #define p_mclk_in null
 #endif
@@ -124,70 +124,70 @@ on tile[AUDIO_IO_TILE] :  in port p_mclk_in                 = PORT_MCLK_IN;
 #if (SECOND_MCLK_REQUIRED)
 /* If audio I/O and USB running on different tiles we need a separate port for
  * the master clock input (to use for USB async feedback calculation) */
-on tile[XUD_TILE] : in port p_mclk_in_usb                   = PORT_MCLK_IN_USB;
+on tile[XUA_XUD_TILE_NUM] : in port p_mclk_in_usb                   = PORT_MCLK_IN_USB;
 #endif
 
 #if XUA_USB_EN
-on tile[XUD_TILE] : in port p_for_mclk_count                = PORT_MCLK_COUNT;
+on tile[XUA_XUD_TILE_NUM] : in port p_for_mclk_count                = PORT_MCLK_COUNT;
 #endif
 
 #if (XUA_SPDIF_TX_EN)
-on tile[SPDIF_TX_TILE] : buffered out port:32 p_spdif_tx    = PORT_SPDIF_OUT;
+on tile[XUA_SPDIF_TX_TILE_NUM] : buffered out port:32 p_spdif_tx    = PORT_SPDIF_OUT;
 #endif
 
 #if (XUA_ADAT_TX_EN)
-on stdcore[AUDIO_IO_TILE] : buffered out port:32 p_adat_tx  = PORT_ADAT_OUT;
+on stdcore[XUA_AUDIO_IO_TILE_NUM] : buffered out port:32 p_adat_tx  = PORT_ADAT_OUT;
 #endif
 
 #if (XUA_ADAT_RX_EN)
-on stdcore[XUD_TILE] : buffered in port:32 p_adat_rx        = PORT_ADAT_IN;
+on stdcore[XUA_XUD_TILE_NUM] : buffered in port:32 p_adat_rx        = PORT_ADAT_IN;
 #endif
 
 #if (XUA_SPDIF_RX_EN)
-on tile[XUD_TILE] : in port p_spdif_rx                      = PORT_SPDIF_IN;
+on tile[XUA_XUD_TILE_NUM] : in port p_spdif_rx                      = PORT_SPDIF_IN;
 #endif
 
 #if (XUA_SPDIF_RX_EN) || (XUA_ADAT_RX_EN) || (XUA_SYNCMODE == XUA_SYNCMODE_SYNC)
 /* Reference to external clock multiplier */
-on tile[PLL_REF_TILE] : out port p_pll_ref                  = PORT_PLL_REF;
+on tile[XUA_PLL_REF_TILE_NUM] : out port p_pll_ref                  = PORT_PLL_REF;
 #ifdef __XS3A__
-on tile[AUDIO_IO_TILE] : port p_for_mclk_count_audio        = PORT_MCLK_COUNT_2;
+on tile[XUA_AUDIO_IO_TILE_NUM] : port p_for_mclk_count_audio        = PORT_MCLK_COUNT_2;
 #else /* __XS3A__ */
 #define p_for_mclk_count_audio                              null
 #endif /* __XS3A__ */
 #endif
 
 #ifdef MIDI
-on tile[MIDI_TILE] :  port p_midi_tx                        = PORT_MIDI_OUT;
+on tile[XUA_MIDI_TILE_NUM] :  port p_midi_tx                        = PORT_MIDI_OUT;
 
 #if(MIDI_RX_PORT_WIDTH == 4)
-on tile[MIDI_TILE] :  buffered in port:4 p_midi_rx          = PORT_MIDI_IN;
+on tile[XUA_MIDI_TILE_NUM] :  buffered in port:4 p_midi_rx          = PORT_MIDI_IN;
 #elif(MIDI_RX_PORT_WIDTH == 1)
-on tile[MIDI_TILE] :  buffered in port:1 p_midi_rx          = PORT_MIDI_IN;
+on tile[XUA_MIDI_TILE_NUM] :  buffered in port:1 p_midi_rx          = PORT_MIDI_IN;
 #endif
 #endif
 
 
 #ifdef MIDI
-on tile[MIDI_TILE] : clock    clk_midi                      = CLKBLK_MIDI;
+on tile[XUA_MIDI_TILE_NUM] : clock    clk_midi                      = CLKBLK_MIDI;
 #endif
 
 #if (XUA_SPDIF_TX_EN || XUA_ADAT_TX_EN)
-on tile[SPDIF_TX_TILE] : clock    clk_mst_spd               = CLKBLK_SPDIF_TX;
+on tile[XUA_SPDIF_TX_TILE_NUM] : clock    clk_mst_spd               = CLKBLK_SPDIF_TX;
 #endif
 
 #if (XUA_SPDIF_RX_EN)
-on tile[XUD_TILE] : clock    clk_spd_rx                     = CLKBLK_SPDIF_RX;
+on tile[XUA_XUD_TILE_NUM] : clock    clk_spd_rx                     = CLKBLK_SPDIF_RX;
 #endif
 
-on tile[AUDIO_IO_TILE] : clock clk_audio_mclk               = CLKBLK_MCLK;       /* Master clock */
+on tile[XUA_AUDIO_IO_TILE_NUM] : clock clk_audio_mclk               = CLKBLK_MCLK;       /* Master clock */
 
-#if (AUDIO_IO_TILE != XUD_TILE) && XUA_USB_EN
+#if (XUA_AUDIO_IO_TILE_NUM != XUA_XUD_TILE_NUM) && XUA_USB_EN
 /* Separate clock/port for USB feedback calculation */
-on tile[XUD_TILE] : clock clk_audio_mclk_usb                = CLKBLK_MCLK;       /* Master clock */
+on tile[XUA_XUD_TILE_NUM] : clock clk_audio_mclk_usb                = CLKBLK_MCLK;       /* Master clock */
 #endif
 
-on tile[AUDIO_IO_TILE] : clock clk_audio_bclk               = CLKBLK_I2S_BIT;    /* Bit clock */
+on tile[XUA_AUDIO_IO_TILE_NUM] : clock clk_audio_bclk               = CLKBLK_I2S_BIT;    /* Bit clock */
 
 #if XUA_USB_EN
 /* Endpoint type tables for XUD */
@@ -241,7 +241,7 @@ void xscope_user_init()
 }
 #endif
 
-#if (XUA_SPDIF_TX_EN) && (SPDIF_TX_TILE != AUDIO_IO_TILE)
+#if (XUA_SPDIF_TX_EN) && (XUA_SPDIF_TX_TILE_NUM != XUA_AUDIO_IO_TILE_NUM)
 void SpdifTxWrapper(chanend c_spdif_tx)
 {
     unsigned portId;
@@ -263,7 +263,7 @@ void SpdifTxWrapper(chanend c_spdif_tx)
 #endif
 
 void usb_audio_io(chanend ?c_aud_in,
-#if (XUA_SPDIF_TX_EN) && (SPDIF_TX_TILE != AUDIO_IO_TILE)
+#if (XUA_SPDIF_TX_EN) && (XUA_SPDIF_TX_TILE_NUM != XUA_AUDIO_IO_TILE_NUM)
     chanend c_spdif_tx,
 #endif
 #if (MIXER)
@@ -273,7 +273,7 @@ void usb_audio_io(chanend ?c_aud_in,
     streaming chanend ?c_adat_rx,
     chanend ?c_clk_ctl,
     chanend ?c_clk_int
-#if (XUD_TILE != 0)  && (AUDIO_IO_TILE == 0) && (XUA_DFU_EN == 1)
+#if (XUA_XUD_TILE_NUM != 0)  && (XUA_AUDIO_IO_TILE_NUM == 0) && (XUA_DFU_EN == 1)
     , server interface i_dfu ?dfuInterface
 #endif
 #if (XUA_NUM_PDM_MICS > 0)
@@ -307,7 +307,7 @@ void usb_audio_io(chanend ?c_aud_in,
 #endif /* (XUA_SPDIF_RX_EN || XUA_ADAT_RX_EN) */
 
 
-#if (XUA_SPDIF_TX_EN) && (SPDIF_TX_TILE == AUDIO_IO_TILE)
+#if (XUA_SPDIF_TX_EN) && (XUA_SPDIF_TX_TILE_NUM == XUA_AUDIO_IO_TILE_NUM)
     chan c_spdif_tx;
 
     /* Setup S/PDIF tx port - note this is done before par since sharing clock-block/port */
@@ -324,7 +324,7 @@ void usb_audio_io(chanend ?c_aud_in,
         }
 #endif
 
-#if (XUA_SPDIF_TX_EN) && (SPDIF_TX_TILE == AUDIO_IO_TILE)
+#if (XUA_SPDIF_TX_EN) && (XUA_SPDIF_TX_TILE_NUM == XUA_AUDIO_IO_TILE_NUM)
         while(1)
         {
             spdif_tx(p_spdif_tx, c_spdif_tx);
@@ -340,7 +340,7 @@ void usb_audio_io(chanend ?c_aud_in,
 #define AUDIO_CHANNEL c_aud_in
 #endif
             XUA_AudioHub(AUDIO_CHANNEL, clk_audio_mclk, clk_audio_bclk, p_mclk_in, p_lrclk, p_bclk, p_i2s_dac, p_i2s_adc
-#if (XUA_SPDIF_TX_EN) //&& (SPDIF_TX_TILE != AUDIO_IO_TILE)
+#if (XUA_SPDIF_TX_EN) //&& (XUA_SPDIF_TX_TILE_NUM != XUA_AUDIO_IO_TILE_NUM)
                 , c_spdif_tx
 #endif
 #if (XUA_SPDIF_RX_EN || XUA_ADAT_RX_EN)
@@ -349,7 +349,7 @@ void usb_audio_io(chanend ?c_aud_in,
 #if (XUA_SYNCMODE == XUA_SYNCMODE_SYNC || XUA_SPDIF_RX_EN || XUA_ADAT_RX_EN)
                 , c_audio_rate_change
 #endif
-#if (XUD_TILE != 0) && (AUDIO_IO_TILE == 0) && (XUA_DFU_EN == 1)
+#if (XUA_XUD_TILE_NUM != 0) && (XUA_AUDIO_IO_TILE_NUM == 0) && (XUA_DFU_EN == 1)
                 , dfuInterface
 #endif
 #if (XUA_NUM_PDM_MICS > 0)
@@ -434,7 +434,7 @@ int main()
 #define c_adat_rx null
 #endif
 
-#if (XUA_SPDIF_TX_EN) && (SPDIF_TX_TILE != AUDIO_IO_TILE)
+#if (XUA_SPDIF_TX_EN) && (XUA_SPDIF_TX_TILE_NUM != XUA_AUDIO_IO_TILE_NUM)
     chan c_spdif_tx;
 #endif
 
@@ -498,13 +498,13 @@ int main()
         USER_MAIN_TASKS
 
 #if (((XUA_SYNCMODE == XUA_SYNCMODE_SYNC  && !XUA_USE_SW_PLL) || XUA_SPDIF_RX_EN || XUA_ADAT_RX_EN))
-        on tile[PLL_REF_TILE]: PllRefPinTask(i_pll_ref, p_pll_ref);
+        on tile[XUA_PLL_REF_TILE_NUM]: PllRefPinTask(i_pll_ref, p_pll_ref);
 #endif
-        on tile[XUD_TILE]:
+        on tile[XUA_XUD_TILE_NUM]:
         par
         {
 #if XUA_USB_EN
-#if ((XUD_TILE == 0) && (XUA_DFU_EN == 1))
+#if ((XUA_XUD_TILE_NUM == 0) && (XUA_DFU_EN == 1))
             /* Check if USB is on the flash tile (tile 0) */
             /* Expect to be distrbuted into XUA_Endpoint0() */
             [[distribute]]
@@ -536,7 +536,7 @@ int main()
                 set_port_clock(p_for_mclk_count, clk_audio_mclk_usb);
                 start_clock(clk_audio_mclk_usb);
 #else
-                /* AUDIO_IO_TILE == XUD_TILE */
+                /* XUA_AUDIO_IO_TILE_NUM == XUA_XUD_TILE_NUM */
                 /* Clock port from same clock-block as I2S */
                 /* TODO remove asm() */
                 asm("ldw %0, dp[clk_audio_mclk]":"=r"(x));
@@ -593,10 +593,10 @@ int main()
         }
 
 #if ((XUA_SYNCMODE == XUA_SYNCMODE_SYNC || XUA_SPDIF_RX_EN || XUA_ADAT_RX_EN) && XUA_USE_SW_PLL)
-        on tile[AUDIO_IO_TILE]: sw_pll_task(c_sw_pll);
+        on tile[XUA_AUDIO_IO_TILE_NUM]: sw_pll_task(c_sw_pll);
 #endif
 
-        on tile[AUDIO_IO_TILE]:
+        on tile[XUA_AUDIO_IO_TILE_NUM]:
         {
             /* Audio I/O task, includes mixing etc */
             usb_audio_io(
@@ -607,14 +607,14 @@ int main()
                 /* Connect to XUA_Endpoint0() */
                 c_aud_ctl
 #endif
-#if (XUA_SPDIF_TX_EN) && (SPDIF_TX_TILE != AUDIO_IO_TILE)
+#if (XUA_SPDIF_TX_EN) && (XUA_SPDIF_TX_TILE_NUM != XUA_AUDIO_IO_TILE_NUM)
                 , c_spdif_tx
 #endif
 #if (MIXER)
                 , c_mix_ctl
 #endif
                 , c_spdif_rx, c_adat_rx, c_clk_ctl, c_clk_int
-#if (XUD_TILE != 0) && (AUDIO_IO_TILE == 0) && (XUA_DFU_EN == 1)
+#if (XUA_XUD_TILE_NUM != 0) && (XUA_AUDIO_IO_TILE_NUM == 0) && (XUA_DFU_EN == 1)
                 , dfuInterface
 #endif
 #if (XUA_NUM_PDM_MICS > 0)
@@ -634,8 +634,8 @@ int main()
         }
         //:
 
-#if (XUA_SPDIF_TX_EN) && (SPDIF_TX_TILE != AUDIO_IO_TILE)
-        on tile[SPDIF_TX_TILE]:
+#if (XUA_SPDIF_TX_EN) && (XUA_SPDIF_TX_TILE_NUM != XUA_AUDIO_IO_TILE_NUM)
+        on tile[XUA_SPDIF_TX_TILE_NUM]:
         {
             thread_speed();
             SpdifTxWrapper(c_spdif_tx);
@@ -644,7 +644,7 @@ int main()
 
 #ifdef MIDI
         /* MIDI core */
-        on tile[MIDI_TILE]:
+        on tile[XUA_MIDI_TILE_NUM]:
         {
             thread_speed();
             usb_midi(p_midi_rx, p_midi_tx, clk_midi, c_midi, 0);
@@ -652,7 +652,7 @@ int main()
 #endif
 
 #if (XUA_SPDIF_RX_EN)
-        on tile[XUD_TILE]:
+        on tile[XUA_XUD_TILE_NUM]:
         {
             thread_speed();
             spdif_rx(c_spdif_rx, p_spdif_rx, clk_spd_rx, 192000);
@@ -660,7 +660,7 @@ int main()
 #endif
 
 #if (XUA_ADAT_RX_EN)
-        on stdcore[XUD_TILE] :
+        on stdcore[XUA_XUD_TILE_NUM] :
         {
             set_thread_fast_mode_on();
 
@@ -674,7 +674,7 @@ int main()
 
 
 #if XUA_USB_EN
-#if (XUD_TILE != 0) && (AUDIO_IO_TILE != 0) && (XUA_DFU_EN == 1)
+#if (XUA_XUD_TILE_NUM != 0) && (XUA_AUDIO_IO_TILE_NUM != 0) && (XUA_DFU_EN == 1)
         /* Run flash code on its own - hope it gets combined */
         //#warning Running DFU flash code on its own
         on stdcore[0]: DFUHandler(dfuInterface, null);
@@ -683,7 +683,7 @@ int main()
 
 #if (XUA_NUM_PDM_MICS > 0)
         /* PDM Mics running on a separate to AudioHub */
-        on stdcore[PDM_TILE]:
+        on stdcore[XUA_MIC_PDM_TILE_NUM]:
         {
              mic_array_task(c_pdm_pcm);
         }

--- a/lib_xua/src/core/user/audiohw/audiohw.h
+++ b/lib_xua/src/core/user/audiohw/audiohw.h
@@ -17,10 +17,10 @@ void AudioHwInit(void);
 /**
  * @brief   User audio hardware de-initialisation code
  *
- * This function is called when streaming stops (device enumerated but audio is idle) and should contain user code to perform any 
+ * This function is called when streaming stops (device enumerated but audio is idle) and should contain user code to perform any
  * required audio hardware de-initialisation. This can be useful for saving power in the audio sub-system.
- * It is called from audiohub on AUDIO_IO_TILE.
- * 
+ * It is called from audiohub on XUA_AUDIO_IO_TILE_NUM.
+ *
  * Note this callback will only be called if the XUA_LOW_POWER_NON_STREAMING define is set, otherwise lib_xua assumes that I2S
  * is always looping.
  */
@@ -30,7 +30,7 @@ void AudioHwShutdown(void);
  * @brief   User audio hardware configuration code
  *
  * This function is called when on sample rate change and should contain user code to configure audio hardware
- *  (clocking, CODECs etc) for a specific mClk/Sample frequency.  It is called from audiohub on AUDIO_IO_TILE.
+ *  (clocking, CODECs etc) for a specific mClk/Sample frequency.  It is called from audiohub on XUA_AUDIO_IO_TILE_NUM.
  *
  * \param samFreq       The new sample frequency (in Hz)
  *
@@ -49,7 +49,7 @@ void AudioHwConfig(unsigned samFreq, unsigned mClk, unsigned dsdMode, unsigned s
  *
  * This function is called before AudioHwConfig() and should contain user code to mute audio hardware before a
  * sample rate change in order to reduced audible pops/clicks
- * It is called from audiohub on AUDIO_IO_TILE.
+ * It is called from audiohub on XUA_AUDIO_IO_TILE_NUM.
  *
  *  Note, if using the application PLL of a xcore.ai device this function will be called before the master-clock is
  *  changed
@@ -60,7 +60,7 @@ void AudioHwConfig_Mute(void);
  * @brief   User code to un-mute audio hardware
  *
  * This function is called after AudioHwConfig() and should contain user code to un-mute audio hardware after a
- * sample rate change. It is called from audiohub on AUDIO_IO_TILE.
+ * sample rate change. It is called from audiohub on XUA_AUDIO_IO_TILE_NUM.
  */
 void AudioHwConfig_UnMute(void);
 

--- a/lib_xua/src/core/user/audiostream/audiostream.h
+++ b/lib_xua/src/core/user/audiostream/audiostream.h
@@ -6,7 +6,7 @@
 /* Functions that handle functionality that occur on stream start/stop e.g. DAC mute/un-mute.
  * They should be implemented for the external audio hardware arrangement of a specific design.
 
- * Note that these are called from the EP0 code which always resides on XUD_TILE, i.e. the
+ * Note that these are called from the EP0 code which always resides on XUA_XUD_TILE_NUM, i.e. the
  * tile where the USB device code is executed.
  */
 
@@ -14,7 +14,7 @@
  * @brief   User stream start code
  *
  * User code to perform any actions required at every stream start - either input or output.
- * 
+ *
  * /param inputActive	An input stream is active if 1, else inactive if 0
  * /param OutputActive	An output stream is active if 1, else inactive if 0
  */

--- a/lib_xua/src/core/user/suspend/suspend.h
+++ b/lib_xua/src/core/user/suspend/suspend.h
@@ -6,7 +6,7 @@
 /**
  * @brief   User code shut down the xcore during USB suspend
  *
- * It is called from EP0 on the XUD_TILE.
+ * It is called from EP0 on the XUA_XUD_TILE_NUM.
  * This function is called during suspend and should not return until the power setting is complete.
  */
 void XUA_UserSuspendPowerDown();
@@ -14,7 +14,7 @@ void XUA_UserSuspendPowerDown();
 /**
  * @brief   User code power up the xcore at USB resume
  *
- * It is called from EP0 on the XUD_TILE.
+ * It is called from EP0 on the XUA_XUD_TILE_NUM.
  * This function is called during resume and should not return until the power setting is complete.
  */
 void XUA_UserSuspendPowerUp();

--- a/lib_xua/src/core/warnings.xc
+++ b/lib_xua/src/core/warnings.xc
@@ -2,8 +2,10 @@
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 
 /*
-Warnings relating to configuration defines located in this XC source file rather than the xua_conf.h header file in order to avoid multiple warnings being issued when the xua_conf.h header file is included in multiple files.
-*/
+ * Warnings relating to configuration defines located in this XC source file rather than the xua_conf.h
+ * header file in order to avoid multiple warnings being issued when the xua_conf.h header file is
+ * included in multiple files.
+ */
 
 #include "xua_conf_full.h"
 
@@ -82,6 +84,30 @@ Warnings relating to configuration defines located in this XC source file rather
 
 #ifdef XUA_CHAN_BUFF_CTRL
 #warning Using channel to control buffering - this may reduce performance but improve power consumption
+#endif
+
+#ifdef AUDIO_IO_TILE
+#warning "Use of AUDIO_IO_TILE is to be deprecated, use XUA_AUDIO_IO_TILE_NUM instead"
+#endif
+
+#ifdef XUD_TILE
+#warning "Use of XUD_TILE is to be deprecated, use XUA_XUD_TILE_NUM instead"
+#endif
+
+#ifdef MIDI_TILE
+#warning "Use of MIDI_TILE is to be deprecated, use XUA_MIDI_TILE_NUM instead"
+#endif
+
+#ifdef SPDIF_TX_TILE
+#warning "Use of SPDIF_TX_TILE is to be deprecated, use XUA_SPDIF_TX_TILE_NUM instead"
+#endif
+
+#ifdef PDM_TILE
+#warning "Use of PDM_TILE is to be deprecated, use XUA_MIC_PDM_TILE_NUM instead"
+#endif
+
+#ifdef PLL_REF_TILE
+#warning "Use of PLL_REF_TILE is to be deprecated, use XUA_PLL_REF_TILE_NUM instead"
 #endif
 
 #endif

--- a/lib_xua/src/xud_conf.h
+++ b/lib_xua/src/xud_conf.h
@@ -7,8 +7,8 @@
 #include "xua_conf_full.h"
 #include "packet_sizes.h"
 
-/* Link lib_xua's XUD_TILE to lib_xud's USB_TILE */
-#define USB_TILE tile[XUD_TILE]
+/* Link lib_xua's XUA_XUD_TILE_NUM to lib_xud's USB_TILE */
+#define USB_TILE tile[XUA_XUD_TILE_NUM]
 
 /* Update XUD_USB_ISO_EP_MAX_TXN_SIZE if HiBW enabled */
 #define STR_HELPER(x) #x

--- a/tests/xua_hw_tests/test_dfu/src/xua_conf.h
+++ b/tests/xua_hw_tests/test_dfu/src/xua_conf.h
@@ -3,8 +3,8 @@
 #ifndef _XUA_CONF_H_
 #define _XUA_CONF_H_
 
-#define XUD_TILE (0)
-#define AUDIO_IO_TILE (1)
+#define XUA_XUD_TILE_NUM      (0)
+#define XUA_AUDIO_IO_TILE_NUM (1)
 
 #define MCLK_441 (512 * 44100)
 #define MCLK_48 (512 * 48000)

--- a/tests/xua_sim_tests/test_audio_stop_start/src/main.xc
+++ b/tests/xua_sim_tests/test_audio_stop_start/src/main.xc
@@ -20,22 +20,22 @@
 #define ADC_PORT  XS1_PORT_1B
 #endif
 
-on tile[AUDIO_IO_TILE] : buffered out port:32 p_i2s_dac[I2S_WIRES_DAC] =  {DAC_PORT};
-on tile[AUDIO_IO_TILE] : buffered in port:32 p_i2s_adc[I2S_WIRES_ADC] =   {ADC_PORT};
+on tile[XUA_AUDIO_IO_TILE_NUM] : buffered out port:32 p_i2s_dac[I2S_WIRES_DAC] =  {DAC_PORT};
+on tile[XUA_AUDIO_IO_TILE_NUM] : buffered in port:32 p_i2s_adc[I2S_WIRES_ADC] =   {ADC_PORT};
 
 
-on tile[AUDIO_IO_TILE] : buffered out port:32 p_lrclk        = XS1_PORT_1C;    /* I2S Bit-clock */
-on tile[AUDIO_IO_TILE] : buffered out port:32 p_bclk         = XS1_PORT_1E;     /* I2S L/R-clock */
-on tile[AUDIO_IO_TILE] : in port p_mclk_in                   = XS1_PORT_1D;
+on tile[XUA_AUDIO_IO_TILE_NUM] : buffered out port:32 p_lrclk        = XS1_PORT_1C;    /* I2S Bit-clock */
+on tile[XUA_AUDIO_IO_TILE_NUM] : buffered out port:32 p_bclk         = XS1_PORT_1E;     /* I2S L/R-clock */
+on tile[XUA_AUDIO_IO_TILE_NUM] : in port p_mclk_in                   = XS1_PORT_1D;
 
 /* Clock-block declarations */
-clock clk_audio_bclk                = on tile[AUDIO_IO_TILE]: XS1_CLKBLK_1;   /* Bit clock */
-clock clk_audio_mclk                = on tile[AUDIO_IO_TILE]: XS1_CLKBLK_2;   /* Master clock */
+clock clk_audio_bclk                = on tile[XUA_AUDIO_IO_TILE_NUM]: XS1_CLKBLK_1;   /* Bit clock */
+clock clk_audio_mclk                = on tile[XUA_AUDIO_IO_TILE_NUM]: XS1_CLKBLK_2;   /* Master clock */
 
 
 #ifdef SIMULATION
-out port p_mclk_gen       = on tile[AUDIO_IO_TILE] : XS1_PORT_1M;
-clock clk_audio_mclk_gen  = on tile[AUDIO_IO_TILE] : XS1_CLKBLK_3;
+out port p_mclk_gen       = on tile[XUA_AUDIO_IO_TILE_NUM] : XS1_PORT_1M;
+clock clk_audio_mclk_gen  = on tile[XUA_AUDIO_IO_TILE_NUM] : XS1_CLKBLK_3;
 void master_mode_clk_setup(void);
 #endif
 
@@ -153,7 +153,7 @@ int main(void)
 
     par
     {
-        on tile[AUDIO_IO_TILE]:
+        on tile[XUA_AUDIO_IO_TILE_NUM]:
         {
             par
             {

--- a/tests/xua_sim_tests/test_audio_stop_start/src/xua_conf.h
+++ b/tests/xua_sim_tests/test_audio_stop_start/src/xua_conf.h
@@ -5,8 +5,8 @@
 
 #define EXCLUDE_USB_AUDIO_MAIN
 #define XUA_NUM_PDM_MICS 0
-#define XUD_TILE 0
-#define AUDIO_IO_TILE 1
+#define XUA_XUD_TILE_NUM 0
+#define XUA_AUDIO_IO_TILE_NUM 1
 #define MIXER 0
 
 #ifndef MCLK_441

--- a/tests/xua_sim_tests/test_decouple_in_overflow/src/xua_conf.h
+++ b/tests/xua_sim_tests/test_decouple_in_overflow/src/xua_conf.h
@@ -16,7 +16,7 @@
 #define UAC_FORCE_FEEDBACK_EP   (0)
 #define XUA_NUM_PDM_MICS        (0)
 
-#define AUDIO_IO_TILE           (0)
+#define XUA_AUDIO_IO_TILE_NUM           (0)
 
 /* Required so that full 32bit result of volume control is used - otherwise breaks our test ramps */
 #define HS_STREAM_FORMAT_INPUT_1_RESOLUTION_BITS 32
@@ -48,7 +48,5 @@
 #define AUDIO_CLASS_FALLBACK    (0)
 #define BCD_DEVICE              (0x1234)
 #define XUA_DFU_EN              (0)
-#define MIC_DUAL_ENABLED        (1)        //Use single thread, dual PDM mic
-#define XUA_MIC_FRAME_SIZE      (240)
 
 #endif

--- a/tests/xua_sim_tests/test_decouple_in_underflow/src/xua_conf.h
+++ b/tests/xua_sim_tests/test_decouple_in_underflow/src/xua_conf.h
@@ -16,7 +16,7 @@
 #define UAC_FORCE_FEEDBACK_EP   (0)
 #define XUA_NUM_PDM_MICS        (0)
 
-#define AUDIO_IO_TILE           (0)
+#define XUA_AUDIO_IO_TILE_NUM   (0)
 
 /* Required so that full 32bit result of volume control is used - otherwise breaks our test ramps */
 #define HS_STREAM_FORMAT_INPUT_1_RESOLUTION_BITS 32
@@ -48,7 +48,5 @@
 #define AUDIO_CLASS_FALLBACK    (0)
 #define BCD_DEVICE              (0x1234)
 #define XUA_DFU_EN              (0)
-#define MIC_DUAL_ENABLED        (1)        //Use single thread, dual PDM mic
-#define XUA_MIC_FRAME_SIZE      (240)
 
 #endif

--- a/tests/xua_sim_tests/test_decouple_out_overflow/src/xua_conf.h
+++ b/tests/xua_sim_tests/test_decouple_out_overflow/src/xua_conf.h
@@ -16,7 +16,7 @@
 #define UAC_FORCE_FEEDBACK_EP   (0)
 #define XUA_NUM_PDM_MICS        (0)
 
-#define AUDIO_IO_TILE           (0)
+#define XUA_AUDIO_IO_TILE_NUM           (0)
 
 /* Required so that full 32bit result of volume control is used - otherwise breaks our test ramps */
 #define HS_STREAM_FORMAT_OUTPUT_1_RESOLUTION_BITS 32
@@ -43,7 +43,5 @@
 #define AUDIO_CLASS_FALLBACK 0
 #define BCD_DEVICE 0x1234
 #define XUA_DFU_EN          0
-#define MIC_DUAL_ENABLED 1        //Use single thread, dual PDM mic
-#define XUA_MIC_FRAME_SIZE 240
 
 #endif

--- a/tests/xua_sim_tests/test_decouple_out_underflow/src/xua_conf.h
+++ b/tests/xua_sim_tests/test_decouple_out_underflow/src/xua_conf.h
@@ -16,7 +16,7 @@
 #define UAC_FORCE_FEEDBACK_EP   (0)
 #define XUA_NUM_PDM_MICS        (0)
 
-#define AUDIO_IO_TILE           (0)
+#define XUA_AUDIO_IO_TILE_NUM           (0)
 
 /* Required so that full 32bit result of volume control is used - otherwise breaks our test ramps */
 #define HS_STREAM_FORMAT_OUTPUT_1_RESOLUTION_BITS 32
@@ -43,7 +43,5 @@
 #define AUDIO_CLASS_FALLBACK 0
 #define BCD_DEVICE 0x1234
 #define XUA_DFU_EN          0
-#define MIC_DUAL_ENABLED 1        //Use single thread, dual PDM mic
-#define XUA_MIC_FRAME_SIZE 240
 
 #endif

--- a/tests/xua_sim_tests/test_i2s_loopback/src/main.xc
+++ b/tests/xua_sim_tests/test_i2s_loopback/src/main.xc
@@ -12,7 +12,7 @@
 
 /* Port declarations. Note, the defines come from the xn file */
 #if I2S_WIRES_DAC > 0
-on tile[AUDIO_IO_TILE] : buffered out port:32 p_i2s_dac[I2S_WIRES_DAC] =
+on tile[XUA_AUDIO_IO_TILE_NUM] : buffered out port:32 p_i2s_dac[I2S_WIRES_DAC] =
                 {PORT_I2S_DAC0,
 #endif
 #if I2S_WIRES_DAC > 1
@@ -41,7 +41,7 @@ on tile[AUDIO_IO_TILE] : buffered out port:32 p_i2s_dac[I2S_WIRES_DAC] =
 #endif
 
 #if I2S_WIRES_ADC > 0
-on tile[AUDIO_IO_TILE] : buffered in port:32 p_i2s_adc[I2S_WIRES_ADC] =
+on tile[XUA_AUDIO_IO_TILE_NUM] : buffered in port:32 p_i2s_adc[I2S_WIRES_ADC] =
                 {PORT_I2S_ADC0,
 #endif
 #if I2S_WIRES_ADC > 1
@@ -81,8 +81,8 @@ in port p_mclk_in                   = PORT_MCLK_IN;
 #endif
 
 /* Clock-block declarations */
-clock clk_audio_bclk                = on tile[AUDIO_IO_TILE]: XS1_CLKBLK_1;   /* Bit clock */
-clock clk_audio_mclk                = on tile[AUDIO_IO_TILE]: XS1_CLKBLK_2;   /* Master clock */
+clock clk_audio_bclk                = on tile[XUA_AUDIO_IO_TILE_NUM]: XS1_CLKBLK_1;   /* Bit clock */
+clock clk_audio_mclk                = on tile[XUA_AUDIO_IO_TILE_NUM]: XS1_CLKBLK_2;   /* Master clock */
 
 #ifdef SIMULATION
 #define INITIAL_SKIP_FRAMES 10
@@ -199,23 +199,23 @@ void checker(chanend c_checker, int disable)
 
 #ifdef SIMULATION
 
-out port p_mclk_gen       = on tile[AUDIO_IO_TILE] :  XS1_PORT_1A;
-clock clk_audio_mclk_gen  = on tile[AUDIO_IO_TILE] : XS1_CLKBLK_3;
-in port p_for_mclk_count  = on tile[XUD_TILE] : XS1_PORT_16A;
+out port p_mclk_gen       = on tile[XUA_AUDIO_IO_TILE_NUM] :  XS1_PORT_1A;
+clock clk_audio_mclk_gen  = on tile[XUA_AUDIO_IO_TILE_NUM] : XS1_CLKBLK_3;
+in port p_for_mclk_count  = on tile[XUA_XUD_TILE_NUM] : XS1_PORT_16A;
 void master_mode_clk_setup(void);
 
 #if CODEC_MASTER
-out port  p_bclk_gen      = on tile[AUDIO_IO_TILE] : XS1_PORT_1B;
-clock clk_audio_bclk_gen  = on tile[AUDIO_IO_TILE] : XS1_CLKBLK_4;
-out port  p_lrclk_gen     = on tile[AUDIO_IO_TILE] : XS1_PORT_1C;
-clock clk_audio_lrclk_gen = on tile[AUDIO_IO_TILE] : XS1_CLKBLK_5;
+out port  p_bclk_gen      = on tile[XUA_AUDIO_IO_TILE_NUM] : XS1_PORT_1B;
+clock clk_audio_bclk_gen  = on tile[XUA_AUDIO_IO_TILE_NUM] : XS1_CLKBLK_4;
+out port  p_lrclk_gen     = on tile[XUA_AUDIO_IO_TILE_NUM] : XS1_PORT_1C;
+clock clk_audio_lrclk_gen = on tile[XUA_AUDIO_IO_TILE_NUM] : XS1_CLKBLK_5;
 void slave_mode_clk_setup(const unsigned samFreq, const unsigned chans_per_frame);
 #endif
 
 
 void mclk_checker(void)
 {
-  if(AUDIO_IO_TILE == XUD_TILE)
+  if(XUA_AUDIO_IO_TILE_NUM == XUA_XUD_TILE_NUM)
   {
     int x;
     asm("ldw %0, dp[clk_audio_mclk]":"=r"(x));
@@ -263,7 +263,7 @@ int main(void)
 
     par
     {
-        on tile[AUDIO_IO_TILE]:
+        on tile[XUA_AUDIO_IO_TILE_NUM]:
         {
             par
             {
@@ -280,7 +280,7 @@ int main(void)
             }
         }
 #ifdef SIMULATION
-        on tile[XUD_TILE]: mclk_checker();
+        on tile[XUA_XUD_TILE_NUM]: mclk_checker();
 #endif
     }
 

--- a/tests/xua_sim_tests/test_i2s_loopback/src/xk_216_mc/audiohw.xc
+++ b/tests/xua_sim_tests/test_i2s_loopback/src/xk_216_mc/audiohw.xc
@@ -96,8 +96,8 @@ void PllMult(unsigned output, unsigned ref, client interface i2c_master_if i2c)
 #endif
 
 #if !(defined(XUA_SPDIF_RX_EN) || defined(XUA_ADAT_RX_EN)) && defined(USE_FRACTIONAL_N)
-on tile[AUDIO_IO_TILE] : out port p_pll_clk = PORT_PLL_REF;
-on tile[AUDIO_IO_TILE] : clock clk_pll_sync = XS1_CLKBLK_5;
+on tile[XUA_AUDIO_IO_TILE_NUM] : out port p_pll_clk = PORT_PLL_REF;
+on tile[XUA_AUDIO_IO_TILE_NUM] : clock clk_pll_sync = XS1_CLKBLK_5;
 #endif
 
 void wait_us(int microseconds)

--- a/tests/xua_sim_tests/test_i2s_loopback/src/xua_conf.h
+++ b/tests/xua_sim_tests/test_i2s_loopback/src/xua_conf.h
@@ -5,10 +5,10 @@
 
 #define EXCLUDE_USB_AUDIO_MAIN
 #define XUA_NUM_PDM_MICS 0
-#ifndef XUD_TILE
-#define XUD_TILE 1
+#ifndef XUA_XUD_TILE_NUM
+#define XUA_XUD_TILE_NUM 1
 #endif
-#define AUDIO_IO_TILE 0
+#define XUA_AUDIO_IO_TILE_NUM 0
 #define MIXER 0
 
 #ifndef MCLK_441

--- a/tests/xua_sim_tests/test_midi/src/app_midi_simple.xc
+++ b/tests/xua_sim_tests/test_midi/src/app_midi_simple.xc
@@ -13,14 +13,14 @@
 #include "midiinparse.h"
 #include "midioutparse.h"
 
-on tile[MIDI_TILE] :  port p_midi_tx                        = XS1_PORT_4C;
+on tile[XUA_MIDI_TILE_NUM] :  port p_midi_tx                        = XS1_PORT_4C;
 #if(MIDI_RX_PORT_WIDTH == 4)
-on tile[MIDI_TILE] :  buffered in port:4 p_midi_rx          = XS1_PORT_1F;
+on tile[XUA_MIDI_TILE_NUM] :  buffered in port:4 p_midi_rx          = XS1_PORT_1F;
 #elif(MIDI_RX_PORT_WIDTH == 1)
-on tile[MIDI_TILE] :  buffered in port:1 p_midi_rx          = XS1_PORT_1F;
+on tile[XUA_MIDI_TILE_NUM] :  buffered in port:1 p_midi_rx          = XS1_PORT_1F;
 #endif
 #define CLKBLK_MIDI  XS1_CLKBLK_2
-on tile[MIDI_TILE] : clock    clk_midi                      = CLKBLK_MIDI;
+on tile[XUA_MIDI_TILE_NUM] : clock    clk_midi                      = CLKBLK_MIDI;
 
 #define MAX_TEST_COMMANDS       100
 #define TEST_COMMAND_FILE_TX   "midi_tx_cmds.txt"

--- a/tests/xua_sim_tests/test_midi/src/xua_conf.h
+++ b/tests/xua_sim_tests/test_midi/src/xua_conf.h
@@ -16,7 +16,7 @@
 #define EXCLUDE_USB_AUDIO_MAIN
 
 #define MIDI            1
-#define MIDI_TILE       1
+#define XUA_MIDI_TILE_NUM       1
 #define VENDOR_STR      "XMOS"
 #define VENDOR_ID       0x20B1
 #define PRODUCT_STR_A2  "XUA Example"

--- a/tests/xua_sim_tests/test_mixer_routing_input/src/xua_conf.h
+++ b/tests/xua_sim_tests/test_mixer_routing_input/src/xua_conf.h
@@ -15,8 +15,8 @@
 
 #define UAC_FORCE_FEEDBACK_EP   (0)
 #define XUA_NUM_PDM_MICS 0
-#define XUD_TILE 0
-#define AUDIO_IO_TILE 0
+#define XUA_XUD_TILE_NUM 0
+#define XUA_AUDIO_IO_TILE_NUM 0
 
 #ifndef MCLK_441
 #define MCLK_441 (512 * 44100)

--- a/tests/xua_sim_tests/test_mixer_routing_input_ctrl/src/xua_conf.h
+++ b/tests/xua_sim_tests/test_mixer_routing_input_ctrl/src/xua_conf.h
@@ -15,8 +15,8 @@
 
 #define UAC_FORCE_FEEDBACK_EP   (0)
 #define XUA_NUM_PDM_MICS 0
-#define XUD_TILE 0
-#define AUDIO_IO_TILE 0
+#define XUA_XUD_TILE_NUM 0
+#define XUA_AUDIO_IO_TILE_NUM 0
 
 #ifndef MCLK_441
 #define MCLK_441 (512 * 44100)

--- a/tests/xua_sim_tests/test_mixer_routing_output/src/xua_conf.h
+++ b/tests/xua_sim_tests/test_mixer_routing_output/src/xua_conf.h
@@ -15,8 +15,8 @@
 
 #define UAC_FORCE_FEEDBACK_EP   (0)
 #define XUA_NUM_PDM_MICS 0
-#define XUD_TILE 0
-#define AUDIO_IO_TILE 0
+#define XUA_XUD_TILE_NUM 0
+#define XUA_AUDIO_IO_TILE_NUM 0
 
 #ifndef MCLK_441
 #define MCLK_441 (512 * 44100)

--- a/tests/xua_sim_tests/test_mixer_routing_output_ctrl/src/xua_conf.h
+++ b/tests/xua_sim_tests/test_mixer_routing_output_ctrl/src/xua_conf.h
@@ -15,8 +15,8 @@
 
 #define UAC_FORCE_FEEDBACK_EP   (0)
 #define XUA_NUM_PDM_MICS 0
-#define XUD_TILE 0
-#define AUDIO_IO_TILE 0
+#define XUA_XUD_TILE_NUM 0
+#define XUA_AUDIO_IO_TILE_NUM 0
 
 #ifndef MCLK_441
 #define MCLK_441 (512 * 44100)

--- a/tests/xua_sim_tests/test_sync_clk_basic/src/xua_conf.h
+++ b/tests/xua_sim_tests/test_sync_clk_basic/src/xua_conf.h
@@ -13,8 +13,8 @@
 
 #define EXCLUDE_USB_AUDIO_MAIN
 #define XUA_NUM_PDM_MICS 0
-#define XUD_TILE 0
-#define AUDIO_IO_TILE 0
+#define XUA_XUD_TILE_NUM 0
+#define XUA_AUDIO_IO_TILE_NUM 0
 #define MIXER 0
 
 #ifndef MCLK_441

--- a/tests/xua_sim_tests/test_sync_clk_plugin/src/xua_conf.h
+++ b/tests/xua_sim_tests/test_sync_clk_plugin/src/xua_conf.h
@@ -13,8 +13,8 @@
 
 #define EXCLUDE_USB_AUDIO_MAIN
 #define XUA_NUM_PDM_MICS 0
-#define XUD_TILE 0
-#define AUDIO_IO_TILE 0
+#define XUA_XUD_TILE_NUM 0
+#define XUA_AUDIO_IO_TILE_NUM 0
 #define MIXER 0
 
 #ifndef MCLK_441

--- a/tests/xua_unit_tests/src/xua_conf.h
+++ b/tests/xua_unit_tests/src/xua_conf.h
@@ -13,9 +13,8 @@
 #define EXCLUDE_USB_AUDIO_MAIN
 #define XUA_NUM_PDM_MICS 0
 
-#define PDM_TILE 2
-#define XUD_TILE 1
-#define AUDIO_IO_TILE 1
+#define XUA_XUD_TILE_NUM      1
+#define XUA_AUDIO_IO_TILE_NUM 1
 
 #define MIXER 0
 


### PR DESCRIPTION
Derive TILE defines from PORT defines from XN file. 

In theory this allows a complete port to a new HW platform to be done from the XN file (in practice we know thats unlikely..)

Since I was in the area I took the opportunity ("bit a bullet") to change the `TILE` define naming to match our coding standards and tools naming convention since we might later want to add things like:

`#defne XUA_AUDIO_IO_TILE PORT_I2S_DAC0_TILE`

etc

where this give the `tile[]` syntax not just the number.

The renames are as follows:

- AUDIO_IO_TILE -> XUA_AUDIO_IO_TILE_NUM
- XUD_TILE -> XUA_XUD_TILE_NUM
- MIDI_TILE -> XUA_MIDI_TILE_NUM
- SPDIF_TX_TILE -> XUA_SPDIF_TX_TILE_NUM
- PDM_TILE -> XUA_MIC_PDM_TILE_NUM
- PLL_REF_TILE -> XUA_PLL_REF_TILE_NUM

Have updated docs, tests and examples. 

Note: Have kept handling of legacy define names.

(Also removed definition of old mic array based defines)