### PR TITLE
Skip building invalid parameter combos in test_i2s_loopback

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -292,9 +292,6 @@ pipeline {
                 dir("tests") {
                   createVenv(reqFile: "requirements.txt")
                   withVenv {
-                    // Cross-product of all parameters in test_i2s_loopback produces invalid configs
-                    // which cannot be built. They are skipped in pytest, but the build failures
-                    // prevent all the XEs being built before running pytest.
                     dir("xua_sim_tests") {
                       sh 'cmake -G "Unix Makefiles" -B build'
 
@@ -305,9 +302,8 @@ pipeline {
                     }
 
                     dir("xua_unit_tests") {
-                      sh "cmake -G 'Unix Makefiles' -B build"
-                      sh 'xmake -C build -j 16'
-                      sh "pytest -v -n auto --junitxml=pytest_unit.xml"
+                      xcoreBuild()
+                      runPytest()
                     }
                   }
                 }

--- a/tests/xua_sim_tests/test_i2s_loopback/CMakeLists.txt
+++ b/tests/xua_sim_tests/test_i2s_loopback/CMakeLists.txt
@@ -55,6 +55,11 @@ foreach(channel_count ${channel_count_list})
                              list(APPEND EXTRA_FLAGS -DXUD_TILE=0)
                         endif()
                         set(cfg_name simulation_${pcm_format}_${i2s_role}_${channel_count}in_${channel_count}out_${sample_rate}_${word_length}bit_${tile}_xud_tile)
+                        if(${channel_count} GREATER 8 AND ${pcm_format} STREQUAL i2s)
+                            message(STATUS "Skipping invalid config: ${cfg_name}")
+                            continue()
+                        endif()
+
                         set(APP_COMPILER_FLAGS_${cfg_name} ${COMMON_FLAGS} ${EXTRA_FLAGS}
                                                            -DNUM_USB_CHAN_IN=${channel_count}
                                                            -DNUM_USB_CHAN_OUT=${channel_count}


### PR DESCRIPTION
A config generated by cmake should build really...

Makes building a running locally nicer.

This means we could just run xcoreBuild() for the sim tests and remove the build from the tests (removing separate MIDI build). This would mean changing test code though, which I didn't want to touch just yet. This is a good move in that direction, should we wish to.