### PR TITLE
Fix links to app notes in readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -114,8 +114,8 @@ Related application notes
 
 The following application notes use this library:
 
-* `AN01009: Optimising USB Audio for stereo output, battery powered devices <www.xmos.com/application-notes/an01009>`_
-* `AN02019: Using Device Firmware Upgrade (DFU) for USB Audio <www.xmos.com/application-notes/an02019>`_
+* `AN01009: Optimising USB Audio for stereo output, battery powered devices <https://www.xmos.com/application-notes/an01009>`_
+* `AN02019: Using Device Firmware Upgrade (DFU) for USB Audio <https://www.xmos.com/application-notes/an02019>`_
 
 *******
 Support


### PR DESCRIPTION
These were rendering on the website as 

<img width="405" height="89" alt="image" src="https://github.com/user-attachments/assets/8321c804-b8cf-4159-9954-302c7ffa3359" />

Noted as broken links by the link checker