### PR TITLE
Fixing warnings when MIN_FREQ == MAX_FREQ

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,7 +44,7 @@ host_usb_mixer_control/xmos_mixer
 *.dSYM
 *.vcd
 *.pyc
-**/.venv/**
+**/.venv*/**
 **/.vscode/**
 **.egg-info
 *tests/logs/*

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 // This file relates to internal XMOS infrastructure and should be ignored by external users
 
-@Library('xmos_jenkins_shared_library@v0.43.1') _
+@Library('xmos_jenkins_shared_library@v0.43.3') _
 
 getApproval()
 
@@ -21,7 +21,7 @@ pipeline {
 
     string(
       name: 'INFR_APPS_VERSION',
-      defaultValue: 'v3.1.1',
+      defaultValue: 'v3.2.0',
       description: 'The infr_apps version'
     )
     choice(

--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ lib_xua: USB Audio components library
 :scope: General Use
 :description: USB Audio components library
 :category: Audio
-:keywords: USB Audio, I2S, MIDI, HID, DFU
+:keywords: USB Audio, Serial Interface, SRC
 :devices: xcore.ai, xcore-200
 
 *******


### PR DESCRIPTION
When
* MIN_FREQ == MAX_FREQ and,
* not (XUA_LOW_POWER_NON_STREAMING && (XUA_SYNCMODE == XUA_SYNCMODE_ASYNC))

A warning is generated that `resetAsynchFeedback()` is not used