### PR TITLE
Allow user defined mul/div for XUA_FB_USE_REF_CLOCK

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,8 @@ UNRELEASED
   * ADDED:     Optional ``XUA_USER_FUNCTION_CALL_PRE_BUFFER`` define to allow
     running of user code before XUA buffer starts in the ``main()`` function.
     This may be used to initialise global channel ends or interfaces.
+  * CHANGED:   ``FB_USE_REF_CLOCK`` renamed to ``XUA_FB_USE_REF_CLOCK`` and
+    added ability to define rational clock ratio between master and ref clock
 
 5.2.0
 -----

--- a/doc/rst/opt_other.rst
+++ b/doc/rst/opt_other.rst
@@ -45,7 +45,6 @@ There are a few other, lesser used, options available. These are shown in :numre
        This define must be able to be compiled under ``C``.
      - Undefined
 
-
 .. note:: When extending the descriptors to add user interfaces, the descriptors must also be extended to 
           tell the host what kind of device to expect. There are three optional include files which may
           be used to insert code into user descriptors. The expected files in your

--- a/lib_xua/api/xua_conf_default.h
+++ b/lib_xua/api/xua_conf_default.h
@@ -1809,6 +1809,23 @@ enum USBEndpointNumber_Out
 #endif
 
 /**
+ * @brief Derive USB TILE MCLK for async feedback from reference clock.
+ *
+ * When enabled, the clocks are counted from the reference clock. Note there MUST be a rational relationship
+ * between the 100MHz reference clock and the master clock applied to the audio tile for this to work.
+ * You must also define XUA_FB_REF_MUL_48, XUA_FB_REF_DIV_48, XUA_FB_REF_MUL_44 and XUA_FB_REF_DIV_44 if
+ * this feature is enabled. eg. XUA_FB_REF_MUL_48 = 768, XUA_FB_REF_DIV_48 = 3125 for 24.576MHz.
+ * 
+ * Note in some cases the MCLK may not be a rational fraction of the reference clock
+ * (eg. when using APP/Secondary PLL at 44100 kHz). This scheme cannot work in those cases!!
+ * 
+ * This feature also cannot work if an external clock source is enabled (eg. SPDIF or ADAT rx)!!
+ */
+#ifndef XUA_FB_USE_REF_CLOCK
+#define XUA_FB_USE_REF_CLOCK    (0)
+#endif
+
+/**
  * @brief Enable Vendor specific control interface
  *
  * When enabled, device enumerates with an extra Vendor specific control interface with no associated endpoints

--- a/lib_xua/src/core/warnings.xc
+++ b/lib_xua/src/core/warnings.xc
@@ -110,4 +110,14 @@
 #warning "Use of PLL_REF_TILE is to be deprecated, use XUA_PLL_REF_TILE_NUM instead"
 #endif
 
+#if XUA_FB_USE_REF_CLOCK
+    #if (!defined(XUA_FB_REF_MUL_48) || !defined(XUA_FB_REF_DIV_48) || !defined(XUA_FB_REF_MUL_44) || !defined(XUA_FB_REF_DIV_44))
+    #error "When using the reference clock, you must define XUA_FB_REF_MUL_48, XUA_FB_REF_DIV_48, XUA_FB_REF_MUL_44 and XUA_FB_REF_DIV_44"
+    #error "The value 100E6 * XUA_FB_REF_MUL / XUA_FB_REF_DIV must be exactly equal to the MCLK applied to AUDIO_IO_TILE"
+    #endif
+    #if XUA_ADAT_RX_EN || XUA_SPDIF_RX_EN
+    #error "XUA_FB_USE_REF_CLOCK not compatible with digital rx streams due to non phase-locked clock"
+    #endif
 #endif
+
+#endif // XUA_USB_EN

--- a/tests/xua_unit_tests/src/xua_conf.h
+++ b/tests/xua_unit_tests/src/xua_conf.h
@@ -33,4 +33,8 @@
 /* TODO */
 #define XUA_DFU XUA_DFU_EN
 
-#define FB_USE_REF_CLOCK 1
+#define XUA_FB_USE_REF_CLOCK 1
+#define XUA_FB_REF_MUL_48 768
+#define XUA_FB_REF_DIV_48 3125
+#define XUA_FB_REF_MUL_44 768
+#define XUA_FB_REF_DIV_44 3375


### PR DESCRIPTION
To support afenext which needs 12.288 MHz mclk