### PR TITLE
Fix missing lib optional header and refactor naming

### DIFF
--- a/doc/rst/opt_other.rst
+++ b/doc/rst/opt_other.rst
@@ -53,8 +53,8 @@ There are a few other, lesser used, options available. These are shown in :numre
           to populate them. The include files must be able to be compiled under ``C``.
 
 .. note:: In addition to adding user interfaces and descriptors, endpoint 0 handlers and endpoint initialisation must
-          be supplied. The expected files in your project are ``xua_user_endpoint0_decl.h`` to make declarations
-          (for example external function prototype), ``xua_user_endpoint0_handler.h`` to provide handling code for
+          be supplied. The expected files in your project are ``xua_user_ep0_decl.h`` to make declarations
+          (for example external function prototype), ``xua_user_ep0_handler.h`` to provide handling code for
           the extensions to endpoint 0 and ``xua_user_endpoint_init.h`` where the additionally declared endpoints
           are initialised. The include files for endpoint 0 must be able to be compiled under ``C``.
 

--- a/lib_xua/lib_build_info.cmake
+++ b/lib_xua/lib_build_info.cmake
@@ -32,9 +32,8 @@ set(LIB_OPTIONAL_HEADERS    xua_conf.h
                             xua_user_descriptors_decl.h
                             xua_user_descriptors_content.h
                             xua_user_endpoint_init.h
-                            xua_user_ep0_init.h
                             xua_user_ep0_decl.h
-
+                            xua_user_ep0_handler.h
                             )
 
 set(LIB_DEPENDENT_MODULES "lib_adat(2.0.1)"

--- a/lib_xua/module_build_info
+++ b/lib_xua/module_build_info
@@ -35,7 +35,18 @@ XCC_FLAGS_dfu.xc = $(MODULE_XCC_FLAGS) -Os -mno-dual-issue
 XCC_FLAGS_flash_interface.c = $(MODULE_XCC_FLAGS) -Os -mno-dual-issue
 XCC_FLAGS_flashlib_user.c = $(MODULE_XCC_FLAGS) -Os -mno-dual-issue
 
-OPTIONAL_HEADERS += xua_conf.h xua_conf_globals.h xua_conf_declarations.h xua_conf_cores.h xua_conf_tasks.h static_hid_report.h
+OPTIONAL_HEADERS += xua_conf.h \
+					xua_conf_globals.h \
+					xua_conf_declarations.h \
+					xua_conf_cores.h \
+					xua_conf_tasks.h \
+					static_hid_report.h \
+					xua_user_descriptors_incl.h \
+					xua_user_descriptors_decl.h \
+					xua_user_descriptors_content.h \
+					xua_user_endpoint_init.h \
+					xua_user_ep0_decl.h \
+					xua_user_ep0_handler.h
 
 EXPORT_INCLUDE_DIRS = api \
                       src/core \

--- a/lib_xua/src/core/endpoint0/xua_endpoint0.c
+++ b/lib_xua/src/core/endpoint0/xua_endpoint0.c
@@ -39,8 +39,8 @@
 #include "dsd_support.h"
 #endif
 
-#ifdef __xua_user_endpoint0_decl_h_exists__
-#include "xua_user_endpoint0_decl.h"
+#ifdef __xua_user_ep0_decl_h_exists__
+#include "xua_user_ep0_decl.h"
 #endif
 
 #define DEBUG_UNIT XUA_EP0
@@ -920,8 +920,8 @@ void XUA_Endpoint0_loop(XUD_Result_t result, USB_SetupPacket_t sp, chanend c_ep0
                     }
 
                 // Additional endpoint 0 handling code if declared
-#ifdef __xua_user_endpoint0_handler_h_exists__
-                #include "xua_user_endpoint0_handler.h"
+#ifdef __xua_user_ep0_handler_h_exists__
+                #include "xua_user_ep0_handler.h"
 #endif
 
                 }


### PR DESCRIPTION
Some typos made their way to develop. This wasn't caught because testing on Linux.. Now debugged on Win10 machine