### PR TITLE
On xcore.ai, generate the fixed MCLK in XUA_AudioHub() when required

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,8 @@ UNRELEASED
   * ADDED:     Optional ``XUA_USER_FUNCTION_CALL_PRE_BUFFER`` define to allow
     running of user code before XUA buffer starts in the ``main()`` function.
     This may be used to initialise global channel ends or interfaces.
+  * ADDED:    Support for generating fixed clock using the application PLL for
+    xcore.ai targets
   * CHANGED:   ``FB_USE_REF_CLOCK`` renamed to ``XUA_FB_USE_REF_CLOCK`` and
     added ability to define rational clock ratio between master and ref clock
   * CHANGED:   Use lib_mic_array's new default API

--- a/examples/deps.cmake
+++ b/examples/deps.cmake
@@ -1,3 +1,3 @@
 set(APP_DEPENDENT_MODULES "lib_xua"
-                          "lib_board_support(1.2.1)"
+                          "lib_board_support(develop)"
                           )

--- a/lib_xua/api/xua_audiohub.h
+++ b/lib_xua/api/xua_audiohub.h
@@ -66,7 +66,7 @@ void XUA_AudioHub(
 #if (XUA_SPDIF_RX_EN || XUA_ADAT_RX_EN || defined(__DOXYGEN__))
     , chanend c_dig
 #endif
-#if (XUA_SYNCMODE == XUA_SYNCMODE_SYNC || XUA_SPDIF_RX_EN || XUA_ADAT_RX_EN || defined(__DOXYGEN__))
+#if (ADJUSTABLE_MCLK_REQUIRED || defined(__DOXYGEN__))
     , chanend c_audio_rate_change
 #endif
 #if (((XUA_XUD_TILE_NUM != 0) && (XUA_AUDIO_IO_TILE_NUM == 0) && (XUA_DFU_EN == 1)) || defined(__DOXYGEN__))

--- a/lib_xua/api/xua_buffer.h
+++ b/lib_xua/api/xua_buffer.h
@@ -59,7 +59,7 @@ void XUA_Buffer(
             chanend c_hid,
 #endif
             chanend c_aud
-#if (XUA_SYNCMODE == XUA_SYNCMODE_SYNC) || defined(__DOYXGEN__)
+#if (XUA_SYNCMODE == XUA_SYNCMODE_SYNC) || defined(__DOXYGEN__)
             , chanend c_audio_rate_change
     #if (!XUA_USE_SW_PLL) || defined(__DOXYGEN__)
             , CLIENT_INTERFACE(pll_ref_if, i_pll_ref)
@@ -100,7 +100,7 @@ void XUA_Buffer_Ep(
 #ifdef XUA_CHAN_BUFF_CTRL
             , chanend c_buff_ctrl
 #endif
-#if (XUA_SYNCMODE == XUA_SYNCMODE_SYNC) || defined(__DOYXGEN__)
+#if (XUA_SYNCMODE == XUA_SYNCMODE_SYNC) || defined(__DOXYGEN__)
             , chanend c_audio_rate_change
     #if (!XUA_USE_SW_PLL) || defined(__DOXYGEN__)
             , client interface pll_ref_if i_pll_ref

--- a/lib_xua/api/xua_clocking.h
+++ b/lib_xua/api/xua_clocking.h
@@ -35,12 +35,14 @@ void PllRefPinTask(server interface pll_ref_if i_pll_ref, out port p_sync);
  */
 void clockGen(  NULLABLE_RESOURCE(streaming_chanend_t, c_spdif_rx),
                 NULLABLE_RESOURCE(streaming_chanend_t, c_adat_rx),
+#if (!XUA_USE_SW_PLL || defined __DOXYGEN__)
                 CLIENT_INTERFACE(pll_ref_if, i_pll_ref),
+#endif
                 chanend c_audio,
                 chanend c_clk_ctl,
                 chanend c_clk_int,
                 chanend c_audio_rate_change
-#if (XUA_USE_SW_PLL || defined __DOYXGEN__)
+#if (XUA_USE_SW_PLL || defined __DOXYGEN__)
                 , port p_for_mclk_count_aud
                 , chanend c_sw_pll
 #endif

--- a/lib_xua/api/xua_conf_default.h
+++ b/lib_xua/api/xua_conf_default.h
@@ -1850,10 +1850,10 @@ enum USBEndpointNumber_Out
  * between the 100MHz reference clock and the master clock applied to the audio tile for this to work.
  * You must also define XUA_FB_REF_MUL_48, XUA_FB_REF_DIV_48, XUA_FB_REF_MUL_44 and XUA_FB_REF_DIV_44 if
  * this feature is enabled. eg. XUA_FB_REF_MUL_48 = 768, XUA_FB_REF_DIV_48 = 3125 for 24.576MHz.
- * 
+ *
  * Note in some cases the MCLK may not be a rational fraction of the reference clock
  * (eg. when using APP/Secondary PLL at 44100 kHz). This scheme cannot work in those cases!!
- * 
+ *
  * This feature also cannot work if an external clock source is enabled (eg. SPDIF or ADAT rx)!!
  */
 #ifndef XUA_FB_USE_REF_CLOCK
@@ -1910,5 +1910,12 @@ enum USBEndpointNumber_Out
     (_NEED_MCLK_FOR_USB && (XUA_XUD_TILE_NUM != XUA_AUDIO_IO_TILE_NUM)) || \
     (_NEED_MCLK_FOR_SPDIF_TX && (XUA_SPDIF_TX_TILE_NUM != XUA_AUDIO_IO_TILE_NUM)) \
 )
+
+/*
+ * Indicates whether an adjustable MCLK is required.
+ *   1 = adjustable MCLK required (USB sync mode or SPDIF/ADAT RX enabled)
+ *   0 = fixed MCLK required (USB async/adapt without digital RX)
+ */
+#define ADJUSTABLE_MCLK_REQUIRED  ((XUA_SYNCMODE == XUA_SYNCMODE_SYNC) || XUA_SPDIF_RX_EN || XUA_ADAT_RX_EN)
 
 #endif /* _XUA_CONF_DEFAULT_H_ */

--- a/lib_xua/lib_build_info.cmake
+++ b/lib_xua/lib_build_info.cmake
@@ -41,7 +41,7 @@ set(LIB_DEPENDENT_MODULES "lib_adat(2.0.1)"
                           "lib_logging(3.4.0)"
                           "lib_spdif(7.0.0)"
                           "lib_sw_pll(2.4.0)"
-                          "lib_xassert(4.3.1)"
+                          "lib_xassert(4.3.2)"
                           "lib_mic_array(develop)"
                           "lib_xud(4.0.0)")
 

--- a/lib_xua/src/core/audiohub/xua_audiohub.xc
+++ b/lib_xua/src/core/audiohub/xua_audiohub.xc
@@ -725,7 +725,7 @@ void XUA_AudioHub(chanend ?c_aud, clock ?clk_audio_mclk, clock ?clk_audio_bclk,
 #if (XUA_ADAT_RX_EN || XUA_SPDIF_RX_EN)
     , chanend c_dig_rx
 #endif
-#if (XUA_SYNCMODE == XUA_SYNCMODE_SYNC || XUA_SPDIF_RX_EN || XUA_ADAT_RX_EN)
+#if ADJUSTABLE_MCLK_REQUIRED
     , chanend c_audio_rate_change
 #endif
 #if (XUA_XUD_TILE_NUM != 0) && (XUA_AUDIO_IO_TILE_NUM == 0) && (XUA_DFU_EN == 1)
@@ -923,8 +923,12 @@ void XUA_AudioHub(chanend ?c_aud, clock ?clk_audio_mclk, clock ?clk_audio_bclk,
                 AudioHwConfig_Mute();
 
                 /* User code should configure audio harware for SampleFreq/MClk etc */
+
+#if defined(__XS3A__) && !ADJUSTABLE_MCLK_REQUIRED
+                sw_pll_fixed_clock(mClk); // output a fixed clock using the application PLL
+#endif
                 AudioHwConfig(curFreq, mClk, dsdMode, curSamRes_DAC, curSamRes_ADC);
-#if (XUA_SYNCMODE == XUA_SYNCMODE_SYNC || XUA_SPDIF_RX_EN || XUA_ADAT_RX_EN)
+#if (ADJUSTABLE_MCLK_REQUIRED)
                 /* Notify clockgen of new mCLk */
                 c_audio_rate_change <: mClk;
                 c_audio_rate_change <: curFreq;

--- a/lib_xua/src/core/clocking/clockgen.xc
+++ b/lib_xua/src/core/clocking/clockgen.xc
@@ -218,7 +218,9 @@ int VendorAudCoreReqs(unsigned cmd, chanend c);
 #pragma unsafe arrays
 void clockGen ( streaming chanend ?c_spdif_rx,
                 streaming chanend ?c_adat_rx,
+#if !XUA_USE_SW_PLL
                 client interface pll_ref_if i_pll_ref,
+#endif
                 chanend c_dig_rx,
                 chanend c_clk_ctl,
                 chanend c_clk_int,
@@ -375,8 +377,10 @@ void clockGen ( streaming chanend ?c_spdif_rx,
     outuint(c_dig_rx, 1);
 #endif
 
+#if !XUA_USE_SW_PLL
     /* Initial ref clock output and get timestamp */
     i_pll_ref.init();
+#endif
 
 #if ((XUA_SPDIF_RX_EN || XUA_ADAT_RX_EN) && XUA_USE_SW_PLL)
     int reset_sw_pll_pfd = 1;

--- a/tests/xua_hw_tests/test_control/device/CMakeLists.txt
+++ b/tests/xua_hw_tests/test_control/device/CMakeLists.txt
@@ -5,8 +5,7 @@ project(control_test)
 set(XMOS_SANDBOX_DIR ${CMAKE_CURRENT_LIST_DIR}/../../../../..)
 
 set(APP_HW_TARGET xk-audio-316-mc.xn)
-set(APP_DEPENDENT_MODULES "lib_xua"
-                          "lib_board_support(1.1.0)")
+include(${CMAKE_CURRENT_LIST_DIR}/../../../../examples/deps.cmake)
 
 set(COMMON_FLAGS -O3
                  -lquadflash

--- a/tests/xua_hw_tests/test_dfu/CMakeLists.txt
+++ b/tests/xua_hw_tests/test_dfu/CMakeLists.txt
@@ -5,8 +5,7 @@ project(dfu_test)
 set(XMOS_SANDBOX_DIR ${CMAKE_CURRENT_LIST_DIR}/../../../..)
 
 set(APP_HW_TARGET xk-audio-316-mc.xn)
-set(APP_DEPENDENT_MODULES "lib_xua"
-                          "lib_board_support(1.1.0)")
+include(${CMAKE_CURRENT_LIST_DIR}/../../../examples/deps.cmake)
 set(APP_INCLUDES src)
 
 set(COMMON_FLAGS -O3

--- a/tests/xua_hw_tests/test_dfu/src/audiohw.xc
+++ b/tests/xua_hw_tests/test_dfu/src/audiohw.xc
@@ -15,10 +15,10 @@
 #endif
 
 static xk_audio_316_mc_ab_config_t config = {
-    (XUA_SYNCMODE == XUA_SYNCMODE_SYNC || XUA_SPDIF_RX_EN || XUA_ADAT_RX_EN)
+    ADJUSTABLE_MCLK_REQUIRED
     ? ( XUA_USE_SW_PLL
         ? CLK_PLL : CLK_CS2100 )
-    : CLK_FIXED,          // clk_mode
+    : CLK_NONE,          // clk_mode
     CODEC_MASTER,         // dac_is_clk_master
     MCLK_48,              // default_mclk
     PLL_SYNC_FREQ,        // pll_sync_freq

--- a/tests/xua_sim_tests/test_audio_stop_start.py
+++ b/tests/xua_sim_tests/test_audio_stop_start.py
@@ -25,7 +25,7 @@ def do_test(options, capfd, cfg):
     )
 
 
-    max_cycles = 6000000  # enough to send all of the frames in the test and hit exit(0)
+    max_cycles = 7000000  # enough to send all of the frames in the test and hit exit(0)
 
     simargs = [
         "--max-cycles",


### PR DESCRIPTION
- Simplify condition under which pll_ref_if/PllRefPinTask() are used/created