### PR TITLE
Fix unused variable warnings when XUA_USB_EN = 0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,8 @@ UNRELEASED
     added ability to define rational clock ratio between master and ref clock
   * CHANGED:   Use lib_mic_array's new default API
   * CHANGED:   Migrated Windows USB DFU host application from 32 bit to 64 bit
+  * FIXED:     Unused variable warnings when XUA_USB_EN = 0
+
 
 5.2.0
 -----

--- a/lib_xua/src/core/main.xc
+++ b/lib_xua/src/core/main.xc
@@ -486,12 +486,16 @@ int main()
 #if (XUA_SYNCMODE == XUA_SYNCMODE_SYNC)
     chan c_audio_rate_change; /* Notification of new mclk freq to ep_buffer */
 #endif
+#if XUA_USB_EN
     chan c_sof;
     chan c_xud_out[ENDPOINT_COUNT_OUT];              /* Endpoint channels for XUD */
     chan c_xud_in[ENDPOINT_COUNT_IN];
-
     /* Used to communicate controls/setting from XUA_Endpoint0() to the Audio/Buffering sub-system */
     chan c_aud_ctl;
+#else
+    #define c_aud_ctl null
+#endif
+
 
 #if (!MIXER)
 #define c_mix_ctl null


### PR DESCRIPTION
https://github.com/xmosnotes/an02052/issues/7

Tested and working on UA and INT builds in an02052