### PR TITLE
In xua_audiohub, account for ADAT/SPDIF TX channels in samplesOut sizing

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ UNRELEASED
   * ADDED: Configurable output channel layout macros for populating UAC2 ``bmChannelConfig``
     and UAC1 ``wChannelConfig`` descriptor fields
   * FIXED: Control and DFU descriptors ordering in UAC1.0 Config descriptor
+  * FIXED: Account for ADAT/SPDIF TX channels in samplesOut sizing in xua_audiohub
 
 5.4.0
 -----

--- a/lib_xua/src/core/audiohub/xua_audiohub.xc
+++ b/lib_xua/src/core/audiohub/xua_audiohub.xc
@@ -52,7 +52,8 @@
     #define _XUA_ENABLE_I2S_TIMING_CHECK (0)
 #endif
 
-unsigned samplesOut[XUA_MAX(NUM_USB_CHAN_OUT, I2S_CHANS_DAC)];
+#define OUT_CHAN_COUNT (I2S_CHANS_DAC + (8*XUA_ADAT_TX_EN) + (2*XUA_SPDIF_TX_EN))
+unsigned samplesOut[XUA_MAX(NUM_USB_CHAN_OUT, OUT_CHAN_COUNT)];
 
 /* Two buffers for ADC data to allow for DAC and ADC I2S ports being offset */
 #define IN_CHAN_COUNT (I2S_CHANS_ADC + XUA_NUM_PDM_MICS + (8*XUA_ADAT_RX_EN) + (2*XUA_SPDIF_RX_EN))


### PR DESCRIPTION
Fixes https://github.com/xmos/lib_xua/issues/567