### PR TITLE
endpoint0: fix control and DFU descriptor ordering for UAC1.0 descriptors

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ UNRELEASED
 
   * ADDED: Configurable output channel layout macros for populating UAC2 ``bmChannelConfig``
     and UAC1 ``wChannelConfig`` descriptor fields
+  * FIXED: Control and DFU descriptors ordering in UAC1.0 Config descriptor
 
 5.4.0
 -----

--- a/lib_xua/src/core/endpoint0/xua_ep0_descriptors.h
+++ b/lib_xua/src/core/endpoint0/xua_ep0_descriptors.h
@@ -2928,21 +2928,21 @@ unsigned char cfgDesc_Audio1[] =
     0x03,                                 /* 4 BaAssocJackID(1) : ID of the Embedded MIDI OUT Jack. (field size 1 bytes) */
 #endif // MIDI
 
-#if XUA_DFU_EN
-    CONFIG_DESC_DFU,
-#endif
-
 #if XUA_USB_CONTROL_DESCS
     /* Control interface descriptor */
     0x09,                                                /* 0 bLength : Size of this descriptor, in bytes. (field size 1 bytes) */
     0x04,                                                /* 1 bDescriptorType : INTERFACE descriptor. (field size 1 bytes) */
-    (OUTPUT_INTERFACES_A1 + INPUT_INTERFACES_A1 + 1),    /* 2 bInterfaceNumber */
+    (INTERFACE_NUMBER_MISC_CONTROL),                     /* 2 bInterfaceNumber */
     0x00,                                                /* 3 bAlternateSetting : Index of this setting. (field size 1 bytes) */
     0x00,                                                /* 4 bNumEndpoints : 0 endpoints. (field size 1 bytes) */
     USB_CLASS_VENDOR_SPECIFIC,                           /* 5 bInterfaceClass : Vendor specific. (field size 1 bytes) */
     0xFF,                                                /* 6 bInterfaceSubclass : (field size 1 bytes) */
     0xFF,                                                /* 7 bInterfaceProtocol : Unused. (field size 1 bytes) */
     offsetof(StringDescTable_t, ctrlStr)/sizeof(char *), /* 8 iInterface */
+#endif
+
+#if XUA_DFU_EN
+    CONFIG_DESC_DFU,
 #endif
 
 #if XUA_OR_STATIC_HID_ENABLED


### PR DESCRIPTION
Fixes https://github.com/xmos/lib_xua/issues/557