### PR TITLE
Avoid unused variable `dfuInterface' when XUA_USB_EN=0

### DIFF
--- a/lib_xua/src/core/main.xc
+++ b/lib_xua/src/core/main.xc
@@ -466,7 +466,7 @@ int main()
 #define c_clk_ctl null
 #endif
 
-#if (XUA_DFU_EN == 1)
+#if ((XUA_DFU_EN == 1) && (XUA_USB_EN == 1))
     interface i_dfu dfuInterface;
 #else
     #define dfuInterface null


### PR DESCRIPTION
Seen in xvf3620 INT_ when DFU is enabled in xua_conf.h