### PR TITLE
Moving dfu conf to lib variant

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 // This file relates to internal XMOS infrastructure and should be ignored by external users
 
-@Library('xmos_jenkins_shared_library@v0.45.0') _
+@Library('xmos_jenkins_shared_library@v0.49.0') _
 
 getApproval()
 
@@ -21,7 +21,7 @@ pipeline {
 
     string(
       name: 'INFR_APPS_VERSION',
-      defaultValue: 'v3.3.0',
+      defaultValue: 'v3.4.0',
       description: 'The infr_apps version'
     )
     choice(

--- a/doc/rst/api_defines.rst
+++ b/doc/rst/api_defines.rst
@@ -89,9 +89,11 @@ PDM microphones
 DFU
 ^^^
 
-.. doxygendefine:: XUA_DFU_EN
+Please see ``lib_dfu`` documentation for additional configuration options,
+these defines can be overridden in an optional header file ``xua_conf_dfu.h``
+file or in the application's ``CMakeLists.txt`` for the relevant build configuration.
 
-.. .. doxygendefine:: DFU_FLASH_DEVICE
+.. doxygendefine:: XUA_DFU_EN
 
 HID
 ^^^

--- a/lib_xua/api/xua_conf_default.h
+++ b/lib_xua/api/xua_conf_default.h
@@ -15,6 +15,10 @@
     #include "xua_conf.h"
 #endif
 
+#ifdef __xua_conf_dfu_h_exists__
+    #include "xua_conf_dfu.h"
+#endif
+
 /*
  * Tile arrangement defines
  */
@@ -494,7 +498,7 @@
  */
 
 /**
- * @brief Disable USB functionalty just leaving AudioHub
+ * @brief Disable USB functionality just leaving AudioHub
  *
  * Default: Enabled
  */

--- a/lib_xua/lib_build_info.cmake
+++ b/lib_xua/lib_build_info.cmake
@@ -27,6 +27,7 @@ set(LIB_OPTIONAL_HEADERS    xua_conf.h
                             xua_conf_declarations.h
                             xua_conf_cores.h
                             xua_conf_tasks.h
+                            xua_conf_dfu.h
                             static_hid_report.h
                             xua_user_descriptors_incl.h
                             xua_user_descriptors_decl.h
@@ -44,7 +45,7 @@ set(LIB_DEPENDENT_MODULES "lib_adat(2.0.1)"
                           "lib_xassert(4.3.2)"
                           "lib_mic_array(7.0.0)"
                           "lib_xud(4.0.1)"
-                          "lib_dfu(2.0.0)")
+                          "lib_dfu(develop)")
 
 set(LIB_COMPILER_FLAGS -O3
                        -fasm-linenum

--- a/lib_xua/module_build_info
+++ b/lib_xua/module_build_info
@@ -16,7 +16,7 @@ DEPENDENT_MODULES = lib_adat(>=2.0.1) \
                     lib_xassert(>=4.3.2) \
                     lib_xud(>=4.0.1) \
                     lib_mic_array(>=7.0.0) \
-                    lib_dfu(>=2.0.0)
+                    lib_dfu
 
 MODULE_XCC_FLAGS = $(XCC_FLAGS) \
                    -O3 \
@@ -41,6 +41,7 @@ OPTIONAL_HEADERS += xua_conf.h \
 					xua_conf_declarations.h \
 					xua_conf_cores.h \
 					xua_conf_tasks.h \
+                    xua_conf_dfu.h \
 					static_hid_report.h \
 					xua_user_descriptors_incl.h \
 					xua_user_descriptors_decl.h \

--- a/lib_xua/src/dfu_conf.h
+++ b/lib_xua/src/dfu_conf.h
@@ -10,4 +10,6 @@
 
 #define DFU_USB_EN XUA_USB_EN
 
+#define DFU_BCD_DEVICE BCD_DEVICE
+
 #endif /* DFU_CONF_H */


### PR DESCRIPTION
Adds "xua_conf_dfu.h" for the app to pass DFU parameters to `lib_dfu`
In `dfu_conf.h` sets DFU_BCD_DEVICE from BCD_DEVICE