### PR TITLE
Release prep

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,16 +1,21 @@
 lib_xua change log
 ==================
 
-UNRELEASED
-----------
+5.5.0
+-----
 
-  * ADDED: Configurable output channel layout macros for populating UAC2 ``bmChannelConfig``
-    and UAC1 ``wChannelConfig`` descriptor fields
+  * ADDED: Configurable output channel layout macros for populating UAC2
+    ``bmChannelConfig`` and UAC1 ``wChannelConfig`` descriptor fields
   * FIXED: Control and DFU descriptors ordering in UAC1.0 Config descriptor
-  * FIXED: Account for ADAT/SPDIF TX channels in samplesOut sizing in xua_audiohub
+  * FIXED: Account for ADAT/SPDIF TX channels in samplesOut sizing in
+    xua_audiohub
   * CHANGED:  DFU features now supported by ``lib_dfu``
   * CHANGED:  DFU now notified of USB enumeration progress by calling
     dfu_set_configured_state() when USB host sends SET_CONFIGURATION request
+
+  * Changes to dependencies:
+
+    - lib_dfu: 2.0.0 -> 2.1.0
 
 5.4.0
 -----

--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@ lib_xua: USB Audio components library
 #####################################
 
 :vendor: XMOS
-:version: 5.4.0
+:version: 5.5.0
 :scope: General Use
 :description: USB Audio components library
 :category: Audio

--- a/lib_xua/api/xua_conf_default.h
+++ b/lib_xua/api/xua_conf_default.h
@@ -862,7 +862,7 @@
  * @brief Device firmware version number in Binary Coded Decimal format: 0xJJMN where JJ: major, M: minor, N: sub-minor version number.
  */
 #ifndef BCD_DEVICE_M
-#define BCD_DEVICE_M             (4)
+#define BCD_DEVICE_M             (5)
 #endif
 
 /**

--- a/lib_xua/lib_build_info.cmake
+++ b/lib_xua/lib_build_info.cmake
@@ -1,5 +1,5 @@
 set(LIB_NAME lib_xua)
-set(LIB_VERSION 5.4.0)
+set(LIB_VERSION 5.5.0)
 set(LIB_INCLUDES api
                  src
                  src/core
@@ -45,7 +45,7 @@ set(LIB_DEPENDENT_MODULES "lib_adat(2.0.1)"
                           "lib_xassert(4.3.2)"
                           "lib_mic_array(7.0.0)"
                           "lib_xud(4.0.1)"
-                          "lib_dfu(develop)")
+                          "lib_dfu(2.1.0)")
 
 set(LIB_COMPILER_FLAGS -O3
                        -fasm-linenum

--- a/lib_xua/module_build_info
+++ b/lib_xua/module_build_info
@@ -1,4 +1,4 @@
-VERSION = 5.4.0
+VERSION = 5.5.0
 
 DEBUG ?= 0
 
@@ -16,7 +16,7 @@ DEPENDENT_MODULES = lib_adat(>=2.0.1) \
                     lib_xassert(>=4.3.2) \
                     lib_xud(>=4.0.1) \
                     lib_mic_array(>=7.0.0) \
-                    lib_dfu
+                    lib_dfu(>=2.1.0)
 
 MODULE_XCC_FLAGS = $(XCC_FLAGS) \
                    -O3 \

--- a/settings.yml
+++ b/settings.yml
@@ -3,7 +3,7 @@
 lib_name: lib_xua
 project: '{{lib_name}}'
 title: '{{lib_name}}: USB Audio components library'
-version: 5.4.0
+version: 5.5.0
 
 documentation:
   exclude_patterns_path: doc/exclude_patterns.inc

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,5 +1,5 @@
 # python_version 3.12.1
-# pip_version 24.2
+# pip_version 26.0
 #
 # The parse_version_from_requirements() function in the installPipfile.groovy
 # file of the Jenkins Shared Library uses the python_version comment to set


### PR DESCRIPTION
Will pass tets when lib_dfu released. Updated lib_dfu to 2.1.0, 