### PR TITLE
Reset dsdMode when switching from Native DSD to PCM

### DIFF
--- a/lib_xua/src/core/buffer/decouple/decouple.xc
+++ b/lib_xua/src/core/buffer/decouple/decouple.xc
@@ -936,6 +936,10 @@ void XUA_Buffer_Decouple(chanend c_mix_out
                 {
                     dsdMode = DSD_MODE_NATIVE;
                 }
+                else
+                {
+                    dsdMode = DSD_MODE_OFF;
+                }
 #endif
                 /* Wait for the audio code to request samples and respond with command */
                 g_output_stream_active = 1;


### PR DESCRIPTION
`dsdMode` is not reset after switching playback from Native DSD back to PCM.

Reproduction:

1. Play a Native DSD stream.
2. Stop playback.
3. Start PCM playback using a PCM alternate setting.
4. Observe that `dsdMode` still remains set to `DSD_MODE_NATIVE`.

The host is already sending PCM data, but the internal state still indicates Native DSD. As a result, PCM samples are passed to the output while the downstream hardware is still handled as Native DSD.

This patch adds the missing explicit reset.

Tested with Native DSD playback followed by PCM playback using PCM altset 1 or 2.
